### PR TITLE
Handle oversized plugins

### DIFF
--- a/dockerize/sites-enabled/prod-ssl.conf
+++ b/dockerize/sites-enabled/prod-ssl.conf
@@ -18,7 +18,7 @@ server {
 
     access_log /var/log/nginx/access.log;
 
-    client_max_body_size 20M;
+    client_max_body_size 30M;
     error_log /var/log/nginx/error.log;
 
     # the port your site will be served on

--- a/dockerize/sites-enabled/prod.conf
+++ b/dockerize/sites-enabled/prod.conf
@@ -18,7 +18,7 @@ server {
 
     access_log /var/log/nginx/access.log;
 
-    client_max_body_size 20M;
+    client_max_body_size 30M;
     error_log /var/log/nginx/error.log;
 
     # the port your site will be served on

--- a/dockerize/sites-enabled/staging-ssl.conf
+++ b/dockerize/sites-enabled/staging-ssl.conf
@@ -18,7 +18,7 @@ server {
 
     access_log /var/log/nginx/access.log;
 
-    client_max_body_size 20M;
+    client_max_body_size 30M;
     error_log /var/log/nginx/error.log;
 
     # the port your site will be served on

--- a/qgis-app/docs.py
+++ b/qgis-app/docs.py
@@ -2,7 +2,6 @@ from django.shortcuts import render
 from django.utils.translation import gettext_lazy as _
 
 
-
 def docs_publish(request):
     """
     Renders the docs_publish page
@@ -10,5 +9,16 @@ def docs_publish(request):
     return render(
         request,
         "flatpages/docs_publish.html",
+        {},
+    )
+
+
+def docs_approval(request):
+    """
+    Renders the docs_approval page
+    """
+    return render(
+        request,
+        "flatpages/docs_approval.html",
         {},
     )

--- a/qgis-app/plugins/forms.py
+++ b/qgis-app/plugins/forms.py
@@ -79,6 +79,10 @@ class PluginVersionForm(ModelForm):
     """
 
     required_css_class = "required"
+    package = forms.FileField(
+        label=_("Plugin Package"),
+        help_text=_("Select the zipped plugin file (maximum size: 25MB)."),
+    )
     changelog = forms.fields.CharField(
         label=_("Changelog"),
         required=False,
@@ -168,8 +172,8 @@ class PackageUploadForm(forms.Form):
     """
 
     package = forms.FileField(
-        label=_("Plugin package"),
-        help_text=_("Please select the zipped file of the plugin."),
+        label=_("Plugin Package"),
+        help_text=_("Select the zipped plugin file (maximum size: 25MB)."),
     )
     experimental = forms.BooleanField(
         required=False,

--- a/qgis-app/plugins/templates/plugins/plugin_sidebar.html
+++ b/qgis-app/plugins/templates/plugins/plugin_sidebar.html
@@ -117,6 +117,12 @@
                 Publish a plugin
               </a>
             </li>
+            {% url 'docs_approval' as docs_approval_url %}
+            <li class="has-child {% if request.path == docs_approval_url %}is-active{% endif %}">
+              <a href="{{ docs_approval_url }}">
+                Approval process
+              </a>
+            </li>
             {% comment %} <li class="has-child {% if request.path == '/docs/manage' %}is-active{% endif %}">
               <a href="/docs/manage">
                 Manage a plugin

--- a/qgis-app/templates/flatpages/docs.html
+++ b/qgis-app/templates/flatpages/docs.html
@@ -1,5 +1,6 @@
 {% extends BASE_TEMPLATE %} 
-{% block leftbar %} 
+{% block menu %} 
+{{ block.super }}
     {% include "plugins/plugin_sidebar.html" %} 
 {% endblock %} 
 

--- a/qgis-app/templates/flatpages/docs_approval.html
+++ b/qgis-app/templates/flatpages/docs_approval.html
@@ -1,0 +1,101 @@
+{% extends 'flatpages/docs.html' %}
+
+{% block content %}
+<div class="responsive-content">
+  <h4>Plugin approval process</h4>
+  <p>
+    The approval of plugins is primarily carried out by contributors. Currently,
+    the primary contributor is Admire Nyakudya (<a href="mailto:addloe@gmail.com">addloe@gmail.com</a>). Do not
+    hesitate to get in touch with him if you have any questions about the plugin
+    approval process.
+  </p>
+  <p>The approval process involves the following steps.</p>
+  <h5>New Plugins</h5>
+  <p>All new plugins follow the rough guidelines outlined below:</p>
+  <ul>
+    <li>
+      Plugin metadata.txt should be properly populated with working links i.e.:
+      <ul>
+        <li>
+          Plugin home page - This link should direct users to a page on a
+          website that describes the plugin functionality. If you do not have a
+          dedicated page on your website that describes plugin usage, please use
+          the README in the repository or use the code repository as the link.
+          Any other links will result in the plugin being rejected.
+        </li>
+        <li>
+          Tracker - This should link to the issue tracker in your code
+          repository.
+        </li>
+        <li>
+          Code repository - This should link to the code repository. It is
+          expected that the code in the repository is accessible and not a zip
+          file. The repository should also be publicly accessible. Plugins that
+          utilize binaries will not be approved. If you feel that there is no
+          way to provide your plugin without binaries, please reach out to the
+          QGIS Developers mailing list to motivate your case or the QGIS PSC for
+          further discussions.
+        </li>
+      </ul>
+    </li>
+  </ul>
+  <p class="alert alert-info">
+    <strong>Note:</strong> Plugins cover a whole range of domains which the person doing the
+    approval might not be versed with. With such an expectation, we will try to
+    do random tests (random plugins will be selected) to see if the plugin
+    installs and runs without crashing QGIS. We also expect plugins to be
+    cross-platform, working on Unix systems and Windows. In the list of
+    published plugins, we have a diverse range of plugins offering different
+    functionality. We encourage plugin developers to collaborate on plugins
+    offering the same functionality as developing plugins with functionality
+    that is almost similar. If you need to enhance a particular plugin, we are
+    able to facilitate this with an existing author. For issues relating to the
+    transfer of ownership, or updating any other metadata about existing
+    plugins, please do not hesitate to contact us through the QGIS Developer
+    mailing lists.
+  </p>
+  <h5>Existing Plugins (New updates)</h5>
+  <p>
+    These are plugins that are already in use and being enhanced by new versions
+    being uploaded. During the approval process, we expect the following:
+  </p>
+  <ul>
+    <li>
+      Properly update metadata to include a changelog. This will be beneficial
+      for users to understand what has changed between versions.
+    </li>
+    <li>Properly annotate versions with new version numbers.</li>
+    <li>
+      We will also check the metadata.txt links i.e. plugin homepage, tracker,
+      etc. to see if they are still working.
+    </li>
+  </ul>
+  <p class="alert alert-info">
+    <strong>Note:</strong> Testing will also be done randomly to see if the plugin still works
+    and does not crash QGIS.
+  </p>
+  <p>
+    We try to publish/approve plugins daily with the exception of weekends. If
+    you have uploaded a plugin on Friday-Sunday, it will most likely be approved
+    on Monday. During extended holiday periods, the timelines might be even
+    longer. We also take into consideration that contributors live in different
+    parts of the world with different public holidays. This might also impact
+    the timelines for approval.
+  </p>
+  <div
+    id="_mcePaste"
+    class="mcePaste"
+    style="
+      position: absolute;
+      left: -10000px;
+      top: 187px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    "
+  >
+    <p style="text-indent: 0px; margin: 0px">dai nomi dei campi)</p>
+    <!-- p, li { white-space: pre-wrap; } -->
+  </div>
+</div>
+{% endblock %}

--- a/qgis-app/templates/flatpages/docs_publish.html
+++ b/qgis-app/templates/flatpages/docs_publish.html
@@ -1,5 +1,4 @@
-{% extends "flatpages/docs.html" %} 
-
+{% extends 'flatpages/docs.html' %}
 
 {% block content %}
 <div class="responsive-content">
@@ -40,13 +39,14 @@
     <li>
       If the plugin has an external dependency, this needs to be clearly stated
       in the About metadata field; you can include a short guide to install
-      Python libs as needed, or opint to existing guides, e.g. for Windows
+      Python libs as needed, or opint to existing guides, e.g. for Windows:
       "<a href="https://landscapearchaeology.org/2018/installing-python-packages-in-qgis-3-for-windows/"
-          >Installing Python packages in QGIS 3 (for Windows)</a>"
+         >Installing Python packages in QGIS 3 (for Windows)</a>"
     </li>
     <li>Don't include binaries</li>
+    <li>The size of the plugin package should not exceed 20MB</li>
   </ul>
-  <p><strong>Recommendations</strong></p>
+  <h4>Recommendations</h4>
   <ul>
     <li>
       Write comments in your code in English, it will make it easier for others
@@ -80,7 +80,7 @@
       or regions.
     </li>
   </ul>
-  <p><strong>Tips and Tricks</strong></p>
+  <h4>Tips and Tricks</h4>
   <ul>
     <li>
       Keep your source repository in good shape:&nbsp;

--- a/qgis-app/templates/flatpages/docs_publish.html
+++ b/qgis-app/templates/flatpages/docs_publish.html
@@ -44,7 +44,7 @@
          >Installing Python packages in QGIS 3 (for Windows)</a>"
     </li>
     <li>Don't include binaries</li>
-    <li>The size of the plugin package should not exceed 20MB</li>
+    <li>The size of the plugin package should not exceed 25MB</li>
   </ul>
   <h4>Recommendations</h4>
   <ul>

--- a/qgis-app/urls.py
+++ b/qgis-app/urls.py
@@ -14,7 +14,7 @@ from drf_yasg.views import get_schema_view
 # to find users app views
 # from users.views import *
 from homepage import homepage
-from docs import docs_publish
+from docs import docs_publish, docs_approval
 from rest_framework import permissions
 
 admin.autodiscover()
@@ -77,6 +77,7 @@ urlpatterns += [
 urlpatterns += [
     url(r"^$", homepage, name="homepage"),
     url(r"^docs/publish", docs_publish, name="docs_publish"),
+    url(r"^docs/approval", docs_approval, name="docs_approval"),
 ]
 
 


### PR DESCRIPTION
Fix for #67 

The feature already exists but is not triggered correctly because the NGINX client_max_body_size is set 20M and the max size allowed by the validator is 25Mb. 
The suggestion here is to keep the validators limit and increase the NGINX client_max_body_size to 30M. In this case, the validator will raise the error explicitly on the upload page when the plugin size limit is reached without being handled by NGINX and generate the Cloudflare error.

Additional changes:

- Update the `Publish a plugin` docs to include this limit
- Add the docs for the `Approval process` (ported from the old version)
