### PR TITLE
Navigation bar improvement

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugin_sidebar.html
+++ b/qgis-app/plugins/templates/plugins/plugin_sidebar.html
@@ -1,164 +1,119 @@
-{% load i18n plugins_tagcloud simplemenu_tags static %}
+{% load i18n plugins_tagcloud simplemenu_tags static plugin_utils %}
 <nav id="sidebar" class="sidebar">
-    <ul class="content-wrapper">
-      <li>
-        <a class="button is-success is-medium" href="{% url "plugin_upload" %}">
-            <i class="fas fa-upload"></i>
-            {% trans "Upload a plugin" %}
-        </a>
-      </li>
-      <hr/>
-      {% get_namedmenu Navigation as menu %}
-      {% for item in menu %}
-        <li class="{% if request.path == item.page.url %}is-active{% endif %}">
-          <a href="{{ item.page.url }}">
-            {% if item.page.url == "/" %}
-                <i class="fas fa-home mr-3"></i>
-            {% elif item.page.url == "/plugins/" %}
-                <i class="fas fa-plug mr-3"></i>
-            {% elif item.page.url == "/plugins/my" %}
-                <i class="fas fa-user mr-3"></i>
-            {% endif %}
-            {{ item.name }}
+  <ul class="content-wrapper">
+    <li>
+      <a class="button is-success is-medium" href="{% url "plugin_upload" %}">
+        <i class="fas fa-upload"></i>
+        {% trans "Upload a plugin" %}
+      </a>
+    </li>
+    <hr/>
+    
+    {% get_navigation_menu user as menu %}
+    {% for item in menu %}
+      {% if item.submenu %}
+        <li>
+          <div class="has-child">
+            <a onclick="toggleSubMenu('{{ item.name }}')">
+              <i class="fas {{ item.icon }} mr-3"></i>
+              {{ item.name }}
+            </a>
+            <span onclick="toggleSubMenu('{{ item.name }}')" class="drop-arrow"><img src="{% static "images/arrow.svg" %}"/></span>
+          </div>
+          <ul class="collapsed" id="{{ item.name }}">
+            {% for subitem in item.submenu %}
+              {% if subitem.submenu %}
+                <li>
+                  <div class="has-child">
+                    <a onclick="toggleSubMenu('{{ subitem.name }}')">
+                      <i class="fas {{ subitem.icon }} mr-3"></i>
+                      {{ subitem.name }}
+                    </a>
+                    <span onclick="toggleSubMenu('{{ subitem.name }}')" class="drop-arrow
+                    "><img src="{% static "images/arrow.svg" %}"/></span>
+                  </div>
+                  <ul class="collapsed"
+                  id="{{ subitem.name }}">
+                    {% for entry in subitem.submenu %}
+                    <li class="has-child {% if request.path == entry.url %}is-active{% endif %}">
+                      <a href="{{ entry.url }}">
+                        {{ entry.name }}
+                      </a>
+                    </li>
+                    {% endfor %}
+                  </ul>
+                </li>
+              {% else %}
+
+                <li class="has-child {% if request.path == subitem.url %}is-active{% endif %}">
+                  <a href="{{ subitem.url }}">
+                    {{ subitem.name }}
+                  </a>
+                </li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+        </li>
+      {% else %}
+        <li class="{% if request.path == item.url %}is-active{% endif %}">
+          <a href="{{ item.url }}">
+          <i class="fas {{ item.icon }} mr-3"></i>
+          {{ item.name }}
           </a>
         </li>
-      {% endfor %}
-      <li>
-        <div class="has-child">
-          <a onclick="toggleSubMenu('news')">
-            <i class="fas fa-newspaper mr-3"></i>
-            New & Updated
-          </a>
-          <span onclick="toggleSubMenu('news')" class="drop-arrow"><img src="{% static "images/arrow.svg" %}"/></span>
-        </div>
-        <ul class="collapsed"  id="news">
-          {% get_namedmenu New as new %}
-          {% for item in new %}
-            <li class="has-child {% if request.path == item.page.url %}is-active{% endif %}">
-              <a href="{{ item.page.url }}">
-                {{ item.name }}
-              </a>
-            </li>
-          {% endfor %}
-        </ul>
-      </li>
-      <li>
-        <div class="has-child">
-          <a onclick="toggleSubMenu('top')">
-            <i class="fas fa-star mr-3"></i>
-            Top
-          </a>
-          <span onclick="toggleSubMenu('top')" class="drop-arrow"><img src="{% static "images/arrow.svg" %}"/></span>
-        </div>
-        <ul class="collapsed" id="top">
-          {% get_namedmenu Top as Top %}
-          {% for item in Top %}
-            <li class="has-child {% if request.path == item.page.url %}is-active{% endif %}">
-              <a href="{{ item.page.url }}">
-                {{ item.name }}
-              </a>
-            </li>
-          {% endfor %}
-        </ul>
-      </li>
-      <li>
-        <div class="has-child">
-          <a onclick="toggleSubMenu('category')">
-            <i class="fas fa-list mr-3"></i>
-            Category
-          </a>
-          <span onclick="toggleSubMenu('category')" class="drop-arrow"><img src="{% static "images/arrow.svg" %}"/></span>
-        </div>
-        <ul class="collapsed" id="category">
-          {% get_namedmenu Category as Category %}
-          {% for item in Category %}
-            <li class="has-child {% if request.path == item.page.url %}is-active{% endif %}">
-              <a href="{{ item.page.url }}">
-                {{ item.name }}
-              </a>
-            </li>
-          {% endfor %}
-        </ul>
-      </li>
-      {% if user.is_authenticated and user.is_staff %}
-      <li>
-        <div class="has-child">
-          <a onclick="toggleSubMenu('unapproved')">
-            <i class="fas fa-check-circle mr-3"></i>
-            Under review
-          </a>
-          <span onclick="toggleSubMenu('unapproved')" class="drop-arrow"><img src="{% static "images/arrow.svg" %}"/></span>
-        </div>
-        <ul class="collapsed" id="unapproved">
-          {% get_namedmenu Unapproved as Unapproved %}
-          {% for item in Unapproved %}
-            <li class="has-child {% if request.path == item.page.url %}is-active{% endif %}">
-              <a href="{{ item.page.url }}">
-                {{ item.name }}
-              </a>
-            </li>
-          {% endfor %}
-        </ul>
-      </li>
       {% endif %}
-  
-      <li>
-        <div class="has-child">
-            <a onclick="toggleSubMenu('docs')">
-            <i class="fas fa-book mr-3"></i>
-            Documentation
-            </a>
-          <span onclick="toggleSubMenu('docs')" class="drop-arrow"><img src="{% static "images/arrow.svg" %}"/></span>
-        </div>
-        <ul class="collapsed" id="docs">
-            {% url 'docs_publish' as docs_publish_url %}
-            <li class="has-child {% if request.path == docs_publish_url %}is-active{% endif %}">
-              <a href="{{ docs_publish_url }}">
-                Publish a plugin
-              </a>
-            </li>
-            {% url 'docs_approval' as docs_approval_url %}
-            <li class="has-child {% if request.path == docs_approval_url %}is-active{% endif %}">
-              <a href="{{ docs_approval_url }}">
-                Approval process
-              </a>
-            </li>
-            {% comment %} <li class="has-child {% if request.path == '/docs/manage' %}is-active{% endif %}">
-              <a href="/docs/manage">
-                Manage a plugin
-              </a>
-            </li> {% endcomment %}
-        </ul>
-      </li>
-      <li>
-        <div>
+    {% endfor %}
+    <li>
+      <div class="has-child">
+        <a onclick="toggleSubMenu('docs')">
+          <i class="fas fa-book mr-3"></i>
+          Documentation
+        </a>
+        <span onclick="toggleSubMenu('docs')" class="drop-arrow"><img src="{% static "images/arrow.svg" %}"/></span>
+      </div>
+      <ul class="collapsed" id="docs">
+        {% url 'docs_publish' as docs_publish_url %}
+        <li class="has-child {% if request.path == docs_publish_url %}is-active{% endif %}">
+          <a href="{{ docs_publish_url }}">
+            Publish a plugin
+          </a>
+        </li>
+        {% url 'docs_approval' as docs_approval_url %}
+        <li class="has-child {% if request.path == docs_approval_url %}is-active{% endif %}">
+          <a href="{{ docs_approval_url }}">
+            Approval process
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li>
+      <div>
         {% include_plugins_tagcloud_modal 'plugins.plugin' %}
-        </div>
-      </li>
-    </ul>
+      </div>
+    </li>
+  </ul>
 </nav>
-  
-  
+
 <script>
-    function rotateArrow(e) {
-        e.previousElementSibling.querySelector('img').classList.toggle('rotated');
-    }
+  function rotateArrow(e) {
+    e.previousElementSibling.querySelector('img').classList.toggle('rotated');
+  }
 
-    function toggleSubMenu(listId) {
-        console.log(listId)
-        let e = document.getElementById(listId);
-        e.classList.toggle('unfolded');
-        rotateArrow(e);
-    }
+  function toggleSubMenu(listId) {
+    console.log(listId)
+    let e = document.getElementById(listId);
+    e.classList.toggle('unfolded');
+    rotateArrow(e);
+  }
 
-    function toggleMenu() {
-        document.getElementById('sidebar').classList.toggle('visible');
-        document.getElementById('hamburger-btn').classList.toggle('open');
+  function toggleMenu() {
+    document.getElementById('sidebar').classList.toggle('visible');
+    document.getElementById('hamburger-btn').classList.toggle('open');
+  }
+  // expand active section
+  document.querySelectorAll('li.is-active,li:has(.is-active)').forEach(li => {
+    if (e = li.querySelector('ul')) {
+      e.classList.toggle('unfolded');
     }
-    // expand active section
-    document.querySelectorAll('li.is-active,li:has(.is-active)').forEach(li => {
-        if (e = li.querySelector('ul')) {
-            e.classList.toggle('unfolded');
-        }
-    });
+  });
 </script>

--- a/qgis-app/plugins/templatetags/plugin_utils.py
+++ b/qgis-app/plugins/templatetags/plugin_utils.py
@@ -109,3 +109,24 @@ def get_sustaining_members_section():
             return f.read()
     except FileNotFoundError:
         return ""
+
+def _filter_menu(menu, user):
+    """
+    Filter the menu and its submenus based on user status
+    """
+    filtered_menu = []
+    for item in menu:
+        if item.get('requires_staff') and not user.is_staff:
+            continue
+        if item.get('requires_login') and not user.is_authenticated:
+            continue
+        filtered_menu.append(item)
+    return filtered_menu
+
+@register.simple_tag()
+def get_navigation_menu(user):
+    """
+    Get the navigation menu from the settings, filtered by user status
+    """
+    menu = _filter_menu(settings.NAVIGATION_MENU, user)
+    return menu

--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -191,3 +191,164 @@ WEBPACK_LOADER = {
         'STATS_FILE': os.path.join(SITE_ROOT, 'webpack-stats.json'),
     }
 }
+
+# News and Updated menus
+NEWS_MENU = [
+    {
+        'name': 'New',
+        'url': '/plugins/fresh/',
+        'order': 0,
+    },
+    {
+        'name': 'Updated',
+        'url': '/plugins/latest/',
+        'order': 1,
+    },
+]
+
+# Featured, popular, most downloaded, most voted, most rated
+TOP_MENU = [
+    {
+        'name': 'Featured',
+        'url': '/plugins/featured/',
+        'order': 0,
+    },
+    {
+        'name': 'Popular',
+        'url': '/plugins/popular/',
+        'order': 1,
+    },
+    {
+        'name': 'Most Downloaded',
+        'url': '/plugins/most_downloaded/',
+        'order': 2,
+    },
+    {
+        'name': 'Most Voted',
+        'url': '/plugins/most_voted/',
+        'order': 3,
+    },
+    {
+        'name': 'Most Rated Plugins',
+        'url': '/plugins/most_rated/',
+        'order': 4,
+    },
+]
+
+# Review Resolved, Review Pending, Awaiting Review
+REVIEW_MENU = [
+    {
+        'name': 'Review Resolved',
+        'url': '/plugins/feedback_completed/',
+        'order': 0,
+    },
+    {
+        'name': 'Review Pending',
+        'url': '/plugins/feedback_received/',
+        'order': 1,
+    },
+    {
+        'name': 'Awaiting Review',
+        'url': '/plugins/feedback_pending/',
+        'order': 2,
+    },
+]
+
+# Stable, experimental, server, deprecated
+OTHER_MENU = [
+    {
+        'name': 'Stable',
+        'url': '/plugins/stable/',
+        'order': 0,
+    },
+    {
+        'name': 'Experimental',
+        'url': '/plugins/experimental/',
+        'order': 1,
+    },
+    {
+        'name': 'Server',
+        'url': '/plugins/server/',
+        'order': 2,
+    },
+    {
+        'name': 'Deprecated',
+        'url': '/plugins/deprecated/',
+        'order': 3,
+    },
+]
+
+# News menus, Top menus, Other menus
+PLUGINS_CATEGORIES = [
+    {
+        'name': 'News and Updated',
+        'url': '#',
+        'icon': 'fa-newspaper',
+        'order': 0,
+        'submenu': NEWS_MENU
+    },
+    {
+        'name': 'Top',
+        'url': '#',
+        'icon': 'fa-star',
+        'order': 1,
+        'submenu': TOP_MENU
+    },
+    {
+        'name': 'Other Categories',
+        'url': '#',
+        'icon': 'fa-ellipsis-h',
+        'order': 3,
+        'submenu': OTHER_MENU
+    },
+]
+
+NAVIGATION_MENU = [
+    {
+        'name': 'QGIS Plugins Home',
+        'url': '/',
+        'icon': 'fa-house',
+        'order': 0,
+    },
+    {
+        'name': 'All Plugins',
+        'url': '/plugins/',
+        'icon': 'fa-plug',
+        'order': 1,
+    },
+    {
+        'name': 'My Plugins',
+        'url': '/plugins/my',
+        'icon': 'fa-user',
+        'order': 2,
+        'requires_login': True,
+    },
+    {
+        'name': 'Review',
+        'url': '#',
+        'icon': 'fa-check',
+        'order': 3,
+        'submenu': REVIEW_MENU,
+        'requires_staff': True
+    },
+    {
+        'name': 'Categories',
+        'url': '#',
+        'icon': 'fa-list',
+        'order': 4,
+        'submenu': PLUGINS_CATEGORIES, 
+    },
+    {
+        'name': 'Metrics',
+        'url': 'https://plugins-analytics.qgis.org',
+        'icon': 'fa-chart-bar',
+        'order': 5,
+    },
+    {
+        'name': 'Admin',
+        'url': '/admin/',
+        'icon': 'fa-tools',
+        'order': 6,
+        'requires_staff': True,
+    },
+]

--- a/qgis-app/static/style/scss/bulma/components/context-menu.sass
+++ b/qgis-app/static/style/scss/bulma/components/context-menu.sass
@@ -12,13 +12,44 @@
   top: 4rem
   z-index: 100
   transition: top 0.3s
-  @media screen and (max-width: 768px)
-    height: 6em
-  .container
-    @media screen and (max-width: 768px)
-      flex-direction: column
-      gap: 10px
-  
+  .navbar
+    background-color: unset
+    min-height: 3em
+    max-height: 54px
+  .navbar-burger
+    color: $primary1-invert
+    margin-left: unset
+    width: 3em
+    height: 3em
+
+  .navbar-start
+    .navbar-item
+      color: white
+      border-radius: 5px
+    .navbar-item, .nabar-link
+      padding: 0.5rem .75rem
+      transition: all 0.3s
+
+    a.navbar-item.is-active,
+    .navbar-link.is-active,
+    .navbar-item
+      color: white
+      background-color: unset
+      &:hover
+        color: #0a0a0a
+        background-color: #fafafa
+
+    .navbar-link
+      color: inherit
+      border-radius: 5px
+
+  .navbar-brand,
+  .navbar-tabs
+    min-height: unset
+    a:hover
+      color: $primary1-invert
+
+    
   input
     background: #223745
     border: none
@@ -34,3 +65,64 @@
     &:focus 
       background: $white
 
+  @media screen and (min-width: 1024px)
+    .navbar-start
+      padding: 10px 0
+      .navbar-dropdown
+        background-color: #002033
+        border: none
+        max-height: calc(100dvh - 112px)
+        overflow: auto
+
+  @media screen and (max-width: 1023px)
+    .container
+      max-width: unset
+    .box
+      padding: 1.25rem 1rem 1.25rem 0rem
+    .navbar-menu
+      background-color: #002033
+      min-width: 150px
+      padding: 1rem
+      &.is-active
+        display: block
+        position: fixed
+        height: calc(100% - 112px)
+        overflow: auto
+        left: 0
+        animation: slideInFromLeft 0.3s ease-out forwards
+      &:not(.is-active)
+        animation: slideOutToLeft 0.3s ease-out forwards
+
+    @keyframes slideInFromLeft
+      from
+        transform: translateX(-100%)
+        opacity: 0
+      to
+        transform: translateX(0)
+        opacity: 1
+
+    @keyframes slideOutToLeft
+      from
+        transform: translateX(0)
+        opacity: 1
+      to
+        transform: translateX(-100%)
+        opacity: 0
+
+    .context-container .navbar-start a.navbar-item.is-active:hover,
+    .context-container .navbar-start .navbar-link.is-active:hover,
+    .context-container .navbar-start .navbar-item:hover
+      background-color: unset !important
+      color: white !important
+
+    .content > .columns .content
+      width: 100%
+
+  // @media screen and (min-width: 1408px)
+  //   .navbar-end
+  //     margin-right: 68px
+
+
+@media screen and (max-width: 1023px)
+  .box
+    padding: 1.25rem 1rem 1.25rem 0rem

--- a/qgis-app/static/style/scss/style.scss
+++ b/qgis-app/static/style/scss/style.scss
@@ -303,11 +303,11 @@ a.is-active > span {
   }
 }
 
-@media screen and (min-width: 1024px) {
-  :root {
-    --qg-nav-max-width: 960px;
-  }
-}
+// @media screen and (min-width: 1024px) {
+//   :root {
+//     --qg-nav-max-width: 960px;
+//   }
+// }
 @media screen and (min-width: 1408px) {
   :root {
     --qg-nav-max-width: 1344px;

--- a/qgis-app/templates/layouts/header.html
+++ b/qgis-app/templates/layouts/header.html
@@ -1,4 +1,4 @@
-{% load i18n simplemenu_tags static %}
+{% load i18n simplemenu_tags plugin_utils static %}
 <div class="box mb-0 context-container" id="context">
     <div class="container">
         <nav class="navbar" role="navigation" aria-label="main navigation">
@@ -20,57 +20,49 @@
             
             <div id="pluginsNavbar" class="navbar-menu">
                 <div class="navbar-start">
-                    {% get_namedmenu Navigation as menu %}
-                        {% for item in menu %}
-                            <a 
-                            class="navbar-item has-text-weight-semibold is-size-7" 
-                            href="{{ item.page.url }}">
-                                <span>{{ item.name }}</span>
-                            </a>
-                        {% endfor %}
-
-                    {% get_namedmenu New as New %}
-                    {% get_namedmenu Top as Top %}
-                    {% get_namedmenu Category as Category %}
-                    <div class="navbar-item has-dropdown is-hoverable has-text-weight-semibold is-size-7">
-                        <a class="navbar-link">
-                          Category
-                        </a>
-                        <div class="navbar-dropdown">
-                            {% for item in New %}
-                            <a href="{{ item.page.url }}" class="navbar-item has-text-weight-semibold is-size-7">
-                                {{ item.name }}
-                            </a>
-                            {% endfor %}
-                            <hr class="navbar-divider">
-                            {% for item in Top %}
-                            <a href="{{ item.page.url }}" class="navbar-item has-text-weight-semibold is-size-7">
-                                {{ item.name }}
-                            </a>
-                            {% endfor %}
-                            <hr class="navbar-divider">
-                            {% for item in Category %}
-                            <a href="{{ item.page.url }}" class="navbar-item has-text-weight-semibold is-size-7">
-                                {{ item.name }}
-                            </a>
-                            {% endfor %}
-                            {% if user.is_authenticated and user.is_staff %}
-                                {% get_namedmenu Unapproved as Unapproved %}
-                                    <hr class="navbar-divider">
-                                    {% for item in Unapproved %}
-                                    <a href="{{ item.page.url }}" class="navbar-item has-text-weight-semibold is-size-7">
-                                        {{ item.name }}
-                                    </a>
+                    {% get_navigation_menu user as menu %}
+                    {% for item in menu %}
+                        {% if item.submenu %}
+                            <div class="navbar-item has-dropdown is-hoverable p-0">
+                                <a class="navbar-link has-text-weight-semibold is-size-7">
+                                    <span class="mr-2">
+                                        <i class="fas {{ item.icon }}"></i>
+                                    </span>
+                                    <span>{{ item.name }}</span>
+                                </a>
+                                <div class="navbar-dropdown">
+                                    {% for subitem in item.submenu %}
+                                        {% if subitem.submenu %}
+                                            {% for entry in subitem.submenu %}
+                                                <a class="navbar-item has-text-weight-semibold is-size-7 ml-1 mr-1" href="{{ entry.url }}">
+                                                    {{ entry.name }}
+                                                </a>
+                                            {% endfor %}
+                                            {% if not forloop.last %}
+                                                <hr class="navbar-divider">
+                                            {% endif %}
+                                        {% else %}
+                                            <a class="navbar-item has-text-weight-semibold is-size-7 ml-1 mr-1" href="{{ subitem.url }}">
+                                                <span class="mr-2">
+                                                    <i class="fas {{ subitem.icon }}"></i>
+                                                </span>
+                                                <span>{{ subitem.name }}</span>
+                                            </a>
+                                        {% endif %}
                                     {% endfor %}
+                                </div>
+                            </div>
+                        {% else %}
+                            {% if item.name != 'Admin' %}
+                                <a class="navbar-item has-text-weight-semibold is-size-7" href="{{ item.url }}">
+                                    <span class="mr-2">
+                                        <i class="fas {{ item.icon }}"></i>
+                                    </span>
+                                    <span>{{ item.name }}</span>
+                                </a>
                             {% endif %}
-                        </div>
-                    </div>
-                    {% if user.is_authenticated and user.is_staff %}
-                    <a class="navbar-item has-text-weight-semibold is-size-7" href="/admin">
-                        <i class="fas fa-tools mr-3"></i>
-                        {% trans "Admin" %}
-                    </a>
-                    {% endif %}
+                        {% endif %}
+                    {% endfor %}
 
                 </div>
                 <div class="navbar-end">
@@ -82,10 +74,10 @@
                             </form>
                         </div>
                     </div>
-                    <div class="navbar-item">
+                    <div class="navbar-item pl-0">
                         {% if user.is_authenticated %}
-                        <a class="button is-warning is-small is-fullwidth" href="{% url "logout" %}">
-                            <span class="icon">
+                        <a class="button is-warning is-small" href="{% url "logout" %}">
+                            <span class="mr-2">
                                 <i class="fas fa-sign-out-alt"></i>
                             </span>
                             <span>
@@ -94,7 +86,7 @@
                         </a>
                         {% else %}
                         <a class="button is-info is-small" href="{% url "login" %}">
-                            <span class="icon">
+                            <span class="mr-2">
                                 <i class="fas fa-sign-in-alt"></i>
                             </span>
                             <span>


### PR DESCRIPTION
Fix for #39 

- Store the menu entries in the settings for explicit and easier management
- This will also check a TODO item from #80 as we don't need to load the menus in the DB anymore
- Show the menu entries based on the user status
- Get the menu entries from the settings in the header and the sidebar
- Move the categorized menus from the sidebar inside the `Categories` menu to match with the header
- Move the `Review` outside the `Categories` to be easily found by plugin reviewers (should also fix #81 )
- Some UI improvements: align them with the global navigation, add icons to the header, move the Admin menu to the sidebar

![image](https://github.com/user-attachments/assets/2c0e948a-24fb-4e87-88bb-0980b385e75b)
