### PR TITLE
Hide featured plugin list on the homepage

### DIFF
--- a/qgis-app/templates/flatpages/home_leftbar.html
+++ b/qgis-app/templates/flatpages/home_leftbar.html
@@ -1,38 +1,40 @@
 {% load i18n plugins_tagcloud thumbnail plugin_utils static %}
 <nav id="sidebar" class="sidebar">
     <ul class="content-wrapper">
-        <li>
-            <div class="has-child">
-                <a href="{% url 'featured_plugins'%}" class="has-text-weight-semibold has-text-success">
-                    <i class="fas fa-medal is-size-5 mr-3"></i>
-                    {% trans "Featured plugins" %}
-                </a>
-            </div>
-            <ul>
-                {% for plugin in featured  %}
-                <li>
-                    <a href="{% url "plugin_detail" plugin.package_name %}">
-                        <span class="mr-2">
-                            {% if plugin.icon and plugin.icon.file and plugin.icon|is_image_valid %}
-                                {% with image_extension=plugin.icon.name|file_extension %}
-                                    {% if image_extension == 'svg' %}
-                                        <img class="pull-right plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ plugin.icon.url }}" width="16" height="16" />
-                                    {% else %}
-                                        {% thumbnail plugin.icon "16x16" format="PNG" as im %}
-                                            <img class="plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" />
-                                        {% endthumbnail %}
-                                    {% endif %}
-                                {% endwith %}
-                            {% else %}
-                                <img height="16" width="16" class="plugin-icon" src="{% static "images/qgis-icon-16x16.png" %}" alt="{% trans "Plugin icon" %}" />
-                            {% endif %}
-                        </span>
-                        {{ plugin.name }}
+        {% if featured %}
+            <li>
+                <div class="has-child">
+                    <a href="{% url 'featured_plugins'%}" class="has-text-weight-semibold has-text-success">
+                        <i class="fas fa-medal is-size-5 mr-3"></i>
+                        {% trans "Featured plugins" %}
                     </a>
-                </li>
-                {% endfor %}
-            </ul>
-        </li>
+                </div>
+                <ul>
+                    {% for plugin in featured  %}
+                    <li>
+                        <a href="{% url "plugin_detail" plugin.package_name %}">
+                            <span class="mr-2">
+                                {% if plugin.icon and plugin.icon.file and plugin.icon|is_image_valid %}
+                                    {% with image_extension=plugin.icon.name|file_extension %}
+                                        {% if image_extension == 'svg' %}
+                                            <img class="pull-right plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ plugin.icon.url }}" width="16" height="16" />
+                                        {% else %}
+                                            {% thumbnail plugin.icon "16x16" format="PNG" as im %}
+                                                <img class="plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" />
+                                            {% endthumbnail %}
+                                        {% endif %}
+                                    {% endwith %}
+                                {% else %}
+                                    <img height="16" width="16" class="plugin-icon" src="{% static "images/qgis-icon-16x16.png" %}" alt="{% trans "Plugin icon" %}" />
+                                {% endif %}
+                            </span>
+                            {{ plugin.name }}
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </li>
+        {% endif %}
         {% if latest %}
         <hr/>
         <li>


### PR DESCRIPTION
Fix for #84 

Hiding the menu should be done through the Admin page