### PR TITLE
Update plugin icon thumbnail size to 48x48 for improved display

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugin_list_grid_card.html
+++ b/qgis-app/plugins/templates/plugins/plugin_list_grid_card.html
@@ -49,7 +49,7 @@ is-one-third-fullhd">
                                     <img alt="{% trans "Plugin icon" %}" src="{{ object.icon.url }}" />
                                 </figure>
                             {% else %}
-                                {% thumbnail object.icon "256x256" format="PNG" as im %}
+                                {% thumbnail object.icon "48x48" format="PNG" as im %}
                                     <figure class="image is-48x48 m-0">
                                         <img alt="{% trans "Plugin icon" %}" src="{{ im.url }}" />
                                     </figure>


### PR DESCRIPTION
Fix for #77 

![image](https://github.com/user-attachments/assets/ebaaf91b-10c4-4b86-bab5-b7e2766c266c)
