### PR TITLE
Add additional search filter for 'about_auto' in SearchWithRequest

### DIFF
--- a/qgis-app/custom_haystack_urls.py
+++ b/qgis-app/custom_haystack_urls.py
@@ -17,12 +17,15 @@ class SearchWithRequest(SearchView):
             sqs1 = SearchQuerySet().filter(
                 description_auto=self.request.GET.get("q", "")
             )
-            sqs2 = SearchQuerySet().filter(name_auto=self.request.GET.get("q", ""))
-            sqs3 = SearchQuerySet().filter(text=self.request.GET.get("q", ""))
-            sqs4 = SearchQuerySet().filter(
+            sqs2 = SearchQuerySet().filter(
+                about_auto=self.request.GET.get("q", "")
+            )
+            sqs3 = SearchQuerySet().filter(name_auto=self.request.GET.get("q", ""))
+            sqs4 = SearchQuerySet().filter(text=self.request.GET.get("q", ""))
+            sqs5 = SearchQuerySet().filter(
                 package_name_auto=self.request.GET.get("q", "")
             )
-            form_kwargs["searchqueryset"] = sqs1 | sqs2 | sqs3 | sqs4
+            form_kwargs["searchqueryset"] = sqs1 | sqs2 | sqs3 | sqs4 | sqs5
 
         return super(SearchWithRequest, self).build_form(form_kwargs)
 


### PR DESCRIPTION
Fix for #75 

This will add the `About` field to the search indexes. It will add more visibility to the plugins when searching with texts that are included in the `About` field.

![image](https://github.com/user-attachments/assets/44e4438a-8ff1-4dce-88e4-e29a81f1d6eb)

## Requirements when deploying

- Clean the content of the `qgis-app/whoosh_index` folder
- Run `make rebuild-index`
