### PR TITLE
Add configurable upload size limits for plugins upload and RPC2

### DIFF
--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -171,7 +171,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 PLUGIN_MAX_UPLOAD_SIZE = os.environ.get("PLUGIN_MAX_UPLOAD_SIZE", 25000000) # Default is 25MB
 
-# RCP2 Max upload size
+# RPC2 Max upload size
 DATA_UPLOAD_MAX_MEMORY_SIZE = PLUGIN_MAX_UPLOAD_SIZE # same as max allowed plugin size
 
 # Sentry

--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -169,6 +169,10 @@ MATOMO_URL="//matomo.qgis.org/"
 # Default primary key type
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
+PLUGIN_MAX_UPLOAD_SIZE = os.environ.get("PLUGIN_MAX_UPLOAD_SIZE", 25000000) # Default is 25MB
+
+# RCP2 Max upload size
+DATA_UPLOAD_MAX_MEMORY_SIZE = PLUGIN_MAX_UPLOAD_SIZE # same as max allowed plugin size
 
 # Sentry
 SENTRY_DSN = os.environ.get("SENTRY_DSN", "")


### PR DESCRIPTION
Fix for #93 

Set the `DATA_UPLOAD_MAX_MEMORY_SIZE` with the same limit as `PLUGIN_MAX_UPLOAD_SIZE` which is 25MB