### PR TITLE
Handle Base64 size for the RPC2 enpoint

### DIFF
--- a/dockerize/sites-enabled/prod-ssl.conf
+++ b/dockerize/sites-enabled/prod-ssl.conf
@@ -22,8 +22,7 @@ server {
     # When changing this, make sure to also change the
     # corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
     # the settings_docker.py file, prod-ssl.conf and staging-ssl.conf
-    # files. Make sure to also change the value in the location /plugins/RPC2 entry
-    # to the corrensponding value (multiplied by 1.33).
+    # files.
     client_max_body_size 25M;
     error_log /var/log/nginx/error.log;
 
@@ -42,23 +41,6 @@ server {
     location ~ (\.php|\.asp|myadmin) {
 	    return 404;
     }
-
-    # Handling of the XML-RPC requests
-    # This is needed for the RPC2 endpoint to handle
-    # the maximum upload size of 25MB because the plugin
-    # archive is automatically translated to Base64 and
-    # the its size is multiplied by 1.33.
-    # See https://github.com/qgis/QGIS-Plugins-Website/pull/111#discussion_r2095807927
-    # This should be changed after the global client_max_body_size changes
-    location /plugins/RPC2 {
-        # Allow larger uploads for plugin archives (Base64 increases size by ~1.33x)
-        client_max_body_size 34M;
-
-        # Pass requests to Django via uwsgi
-        include uwsgi_params;
-        uwsgi_pass uwsgi;
-    }
-
 
     # Django media
     location /media  {
@@ -179,8 +161,7 @@ server {
     # When changing this, make sure to also change the
     # corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
     # the settings_docker.py file, prod-ssl.conf and staging-ssl.conf
-    # files. Make sure to also change the value in the location /plugins/RPC2 entry
-    # to the corrensponding value (multiplied by 1.33).
+    # files.
     client_max_body_size 25M;
     error_log /var/log/nginx/error.log;
 
@@ -190,22 +171,6 @@ server {
     # Its probably someone nefarious probing for vulnerabilities...
     location ~ (\.php|\.asp|myadmin) {
 	    return 404;
-    }
-
-    # Handling of the XML-RPC requests
-    # This is needed for the RPC2 endpoint to handle
-    # the maximum upload size of 25MB because the plugin
-    # archive is automatically translated to Base64 and
-    # the its size is multiplied by 1.33.
-    # See https://github.com/qgis/QGIS-Plugins-Website/pull/111#discussion_r2095807927
-    # This should be changed after the global client_max_body_size changes
-    location /plugins/RPC2 {
-        # Allow larger uploads for plugin archives (Base64 increases size by ~1.33x)
-        client_max_body_size 34M;
-
-        # Pass requests to Django via uwsgi
-        include uwsgi_params;
-        uwsgi_pass uwsgi;
     }
 
     # Django media

--- a/dockerize/sites-enabled/prod-ssl.conf
+++ b/dockerize/sites-enabled/prod-ssl.conf
@@ -18,7 +18,13 @@ server {
 
     access_log /var/log/nginx/access.log;
 
-    client_max_body_size 30M;
+    # Set the maximum body size to 25MB
+    # When changing this, make sure to also change the
+    # corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
+    # the settings_docker.py file, prod-ssl.conf and staging-ssl.conf
+    # files. Make sure to also change the value in the location /plugins/RPC2 entry
+    # to the corrensponding value (multiplied by 1.33).
+    client_max_body_size 25M;
     error_log /var/log/nginx/error.log;
 
     # the port your site will be served on
@@ -36,6 +42,23 @@ server {
     location ~ (\.php|\.asp|myadmin) {
 	    return 404;
     }
+
+    # Handling of the XML-RPC requests
+    # This is needed for the RPC2 endpoint to handle
+    # the maximum upload size of 25MB because the plugin
+    # archive is automatically translated to Base64 and
+    # the its size is multiplied by 1.33.
+    # See https://github.com/qgis/QGIS-Plugins-Website/pull/111#discussion_r2095807927
+    # This should be changed after the global client_max_body_size changes
+    location /plugins/RPC2 {
+        # Allow larger uploads for plugin archives (Base64 increases size by ~1.33x)
+        client_max_body_size 34M;
+
+        # Pass requests to Django via uwsgi
+        include uwsgi_params;
+        uwsgi_pass uwsgi;
+    }
+
 
     # Django media
     location /media  {
@@ -152,7 +175,13 @@ server {
 
     access_log /var/log/nginx/access.log;
 
-    client_max_body_size 30M;
+    # Set the maximum body size to 25MB
+    # When changing this, make sure to also change the
+    # corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
+    # the settings_docker.py file, prod-ssl.conf and staging-ssl.conf
+    # files. Make sure to also change the value in the location /plugins/RPC2 entry
+    # to the corrensponding value (multiplied by 1.33).
+    client_max_body_size 25M;
     error_log /var/log/nginx/error.log;
 
     charset     utf-8;
@@ -161,6 +190,22 @@ server {
     # Its probably someone nefarious probing for vulnerabilities...
     location ~ (\.php|\.asp|myadmin) {
 	    return 404;
+    }
+
+    # Handling of the XML-RPC requests
+    # This is needed for the RPC2 endpoint to handle
+    # the maximum upload size of 25MB because the plugin
+    # archive is automatically translated to Base64 and
+    # the its size is multiplied by 1.33.
+    # See https://github.com/qgis/QGIS-Plugins-Website/pull/111#discussion_r2095807927
+    # This should be changed after the global client_max_body_size changes
+    location /plugins/RPC2 {
+        # Allow larger uploads for plugin archives (Base64 increases size by ~1.33x)
+        client_max_body_size 34M;
+
+        # Pass requests to Django via uwsgi
+        include uwsgi_params;
+        uwsgi_pass uwsgi;
     }
 
     # Django media

--- a/dockerize/sites-enabled/prod.conf
+++ b/dockerize/sites-enabled/prod.conf
@@ -18,7 +18,13 @@ server {
 
     access_log /var/log/nginx/access.log;
 
-    client_max_body_size 30M;
+    # Set the maximum body size to 25MB
+    # When changing this, make sure to also change the
+    # corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
+    # the settings_docker.py file, prod-ssl.conf and staging-ssl.conf
+    # files. Make sure to also change the value in the location /plugins/RPC2 entry
+    # to the corrensponding value (multiplied by 1.33).
+    client_max_body_size 25M;
     error_log /var/log/nginx/error.log;
 
     # the port your site will be served on
@@ -32,6 +38,22 @@ server {
     # Its probably someone nefarious probing for vulnerabilities...
     location ~ (\.php|\.asp|myadmin) {
 	    return 404;
+    }
+
+    # Handling of the XML-RPC requests
+    # This is needed for the RPC2 endpoint to handle
+    # the maximum upload size of 25MB because the plugin
+    # archive is automatically translated to Base64 and
+    # the its size is multiplied by 1.33.
+    # See https://github.com/qgis/QGIS-Plugins-Website/pull/111#discussion_r2095807927
+    # This should be changed after the global client_max_body_size changes
+    location /plugins/RPC2 {
+        # Allow larger uploads for plugin archives (Base64 increases size by ~1.33x)
+        client_max_body_size 34M;
+
+        # Pass requests to Django via uwsgi
+        include uwsgi_params;
+        uwsgi_pass uwsgi;
     }
 
     # Django media

--- a/dockerize/sites-enabled/prod.conf
+++ b/dockerize/sites-enabled/prod.conf
@@ -22,8 +22,7 @@ server {
     # When changing this, make sure to also change the
     # corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
     # the settings_docker.py file, prod-ssl.conf and staging-ssl.conf
-    # files. Make sure to also change the value in the location /plugins/RPC2 entry
-    # to the corrensponding value (multiplied by 1.33).
+    # files.
     client_max_body_size 25M;
     error_log /var/log/nginx/error.log;
 
@@ -38,22 +37,6 @@ server {
     # Its probably someone nefarious probing for vulnerabilities...
     location ~ (\.php|\.asp|myadmin) {
 	    return 404;
-    }
-
-    # Handling of the XML-RPC requests
-    # This is needed for the RPC2 endpoint to handle
-    # the maximum upload size of 25MB because the plugin
-    # archive is automatically translated to Base64 and
-    # the its size is multiplied by 1.33.
-    # See https://github.com/qgis/QGIS-Plugins-Website/pull/111#discussion_r2095807927
-    # This should be changed after the global client_max_body_size changes
-    location /plugins/RPC2 {
-        # Allow larger uploads for plugin archives (Base64 increases size by ~1.33x)
-        client_max_body_size 34M;
-
-        # Pass requests to Django via uwsgi
-        include uwsgi_params;
-        uwsgi_pass uwsgi;
     }
 
     # Django media

--- a/dockerize/sites-enabled/staging-ssl.conf
+++ b/dockerize/sites-enabled/staging-ssl.conf
@@ -17,8 +17,14 @@ server {
     gzip_disable “MSIE [1-6].(?!.*SV1)”;
 
     access_log /var/log/nginx/access.log;
-
-    client_max_body_size 30M;
+    
+    # Set the maximum body size to 25MB
+    # When changing this, make sure to also change the
+    # corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
+    # the settings_docker.py file, prod-ssl.conf and staging-ssl.conf
+    # files. Make sure to also change the value in the location /plugins/RPC2 entry
+    # to the corrensponding value (multiplied by 1.33).
+    client_max_body_size 25M;
     error_log /var/log/nginx/error.log;
 
     # the port your site will be served on
@@ -35,6 +41,22 @@ server {
     # Its probably someone nefarious probing for vulnerabilities...
     location ~ (\.php|\.asp|myadmin) {
 	    return 404;
+    }
+
+    # Handling of the XML-RPC requests
+    # This is needed for the RPC2 endpoint to handle
+    # the maximum upload size of 25MB because the plugin
+    # archive is automatically translated to Base64 and
+    # the its size is multiplied by 1.33.
+    # See https://github.com/qgis/QGIS-Plugins-Website/pull/111#discussion_r2095807927
+    # This should be changed after the global client_max_body_size changes
+    location /plugins/RPC2 {
+        # Allow larger uploads for plugin archives (Base64 increases size by ~1.33x)
+        client_max_body_size 34M;
+
+        # Pass requests to Django via uwsgi
+        include uwsgi_params;
+        uwsgi_pass uwsgi;
     }
 
     # Django media
@@ -152,7 +174,14 @@ server {
 
     access_log /var/log/nginx/access.log;
 
-    client_max_body_size 30M;
+    # Set the maximum body size to 25MB
+    # When changing this, make sure to also change the
+    # corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
+    # the settings_docker.py file, prod-ssl.conf and staging-ssl.conf
+    # files. Make sure to also change the value in the location /plugins/RPC2 entry
+    # to the corrensponding value (multiplied by 1.33).
+    client_max_body_size 25M;
+
     error_log /var/log/nginx/error.log;
 
     charset     utf-8;
@@ -161,6 +190,22 @@ server {
     # Its probably someone nefarious probing for vulnerabilities...
     location ~ (\.php|\.asp|myadmin) {
 	    return 404;
+    }
+
+    # Handling of the XML-RPC requests
+    # This is needed for the RPC2 endpoint to handle
+    # the maximum upload size of 25MB because the plugin
+    # archive is automatically translated to Base64 and
+    # the its size is multiplied by 1.33.
+    # See https://github.com/qgis/QGIS-Plugins-Website/pull/111#discussion_r2095807927
+    # This should be changed after the global client_max_body_size changes
+    location /plugins/RPC2 {
+        # Allow larger uploads for plugin archives (Base64 increases size by ~1.33x)
+        client_max_body_size 34M;
+
+        # Pass requests to Django via uwsgi
+        include uwsgi_params;
+        uwsgi_pass uwsgi;
     }
 
     # Django media

--- a/dockerize/sites-enabled/staging-ssl.conf
+++ b/dockerize/sites-enabled/staging-ssl.conf
@@ -22,8 +22,7 @@ server {
     # When changing this, make sure to also change the
     # corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
     # the settings_docker.py file, prod-ssl.conf and staging-ssl.conf
-    # files. Make sure to also change the value in the location /plugins/RPC2 entry
-    # to the corrensponding value (multiplied by 1.33).
+    # files.
     client_max_body_size 25M;
     error_log /var/log/nginx/error.log;
 
@@ -41,22 +40,6 @@ server {
     # Its probably someone nefarious probing for vulnerabilities...
     location ~ (\.php|\.asp|myadmin) {
 	    return 404;
-    }
-
-    # Handling of the XML-RPC requests
-    # This is needed for the RPC2 endpoint to handle
-    # the maximum upload size of 25MB because the plugin
-    # archive is automatically translated to Base64 and
-    # the its size is multiplied by 1.33.
-    # See https://github.com/qgis/QGIS-Plugins-Website/pull/111#discussion_r2095807927
-    # This should be changed after the global client_max_body_size changes
-    location /plugins/RPC2 {
-        # Allow larger uploads for plugin archives (Base64 increases size by ~1.33x)
-        client_max_body_size 34M;
-
-        # Pass requests to Django via uwsgi
-        include uwsgi_params;
-        uwsgi_pass uwsgi;
     }
 
     # Django media
@@ -178,8 +161,7 @@ server {
     # When changing this, make sure to also change the
     # corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
     # the settings_docker.py file, prod-ssl.conf and staging-ssl.conf
-    # files. Make sure to also change the value in the location /plugins/RPC2 entry
-    # to the corrensponding value (multiplied by 1.33).
+    # files.
     client_max_body_size 25M;
 
     error_log /var/log/nginx/error.log;
@@ -190,22 +172,6 @@ server {
     # Its probably someone nefarious probing for vulnerabilities...
     location ~ (\.php|\.asp|myadmin) {
 	    return 404;
-    }
-
-    # Handling of the XML-RPC requests
-    # This is needed for the RPC2 endpoint to handle
-    # the maximum upload size of 25MB because the plugin
-    # archive is automatically translated to Base64 and
-    # the its size is multiplied by 1.33.
-    # See https://github.com/qgis/QGIS-Plugins-Website/pull/111#discussion_r2095807927
-    # This should be changed after the global client_max_body_size changes
-    location /plugins/RPC2 {
-        # Allow larger uploads for plugin archives (Base64 increases size by ~1.33x)
-        client_max_body_size 34M;
-
-        # Pass requests to Django via uwsgi
-        include uwsgi_params;
-        uwsgi_pass uwsgi;
     }
 
     # Django media

--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -169,6 +169,13 @@ MATOMO_URL="//matomo.qgis.org/"
 # Default primary key type
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
+
+# Set the maximum PLUGIN_MAX_UPLOAD_SIZE size to 25MB
+# When changing this, make sure to also change the
+# corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
+# the prod-ssl.conf and staging-ssl.conf
+# files. Make sure to also change the value in the location /plugins/RPC2 entry
+# to the corrensponding value (multiplied by 1.33).
 PLUGIN_MAX_UPLOAD_SIZE = os.environ.get("PLUGIN_MAX_UPLOAD_SIZE", 25000000) # Default is 25MB
 
 # RPC2 Max upload size

--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -174,8 +174,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 # When changing this, make sure to also change the
 # corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
 # the prod-ssl.conf and staging-ssl.conf
-# files. Make sure to also change the value in the location /plugins/RPC2 entry
-# to the corrensponding value (multiplied by 1.33).
+# files.
 PLUGIN_MAX_UPLOAD_SIZE = os.environ.get("PLUGIN_MAX_UPLOAD_SIZE", 25000000) # Default is 25MB
 
 # RPC2 Max upload size

--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -172,7 +172,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 # Set the maximum PLUGIN_MAX_UPLOAD_SIZE size to 25MB
 # When changing this, make sure to also change the
-# corresponding value in the PLUGIN_MAX_UPLOAD_SIZE in
+# corresponding value in the "client_max_body_size" in
 # the prod-ssl.conf and staging-ssl.conf
 # files.
 PLUGIN_MAX_UPLOAD_SIZE = os.environ.get("PLUGIN_MAX_UPLOAD_SIZE", 25000000) # Default is 25MB


### PR DESCRIPTION
Additional fix for #109 #101 #93 according to https://github.com/qgis/QGIS-Plugins-Website/pull/111#discussion_r2095649710

Cc @Gustry @timlinux 

## Changes summary:
- Set the 34MB limit for the RPC2 endpoint and keep the 25MB limit for others. [Outdated]
- Add comments to explain the Base64 size increase for the RPC2 endpoint. [Outdated]

## Update:

- Keep the 25MB limit everywhere