### PR TITLE
Hide sustaining member anchor

### DIFF
--- a/qgis-app/plugins/tasks/get_sustaining_members.py
+++ b/qgis-app/plugins/tasks/get_sustaining_members.py
@@ -22,9 +22,10 @@ def get_sustaining_members():
         section = soup.select_one('section.section')
 
         if section:
+            html_content = section.prettify().replace("Â¶", "¶")
             template_path = os.path.join(settings.SITE_ROOT, 'templates/flatpages/sustaining_members.html')
             with open(template_path, 'w') as f:
-                f.write(section.prettify())
+                f.write(html_content)
             logger.info(f"get_sustaining_members: Section saved to {template_path}")
         else:
             logger.info("get_sustaining_members: Section not found")

--- a/qgis-app/static/style/scss/style.scss
+++ b/qgis-app/static/style/scss/style.scss
@@ -3,6 +3,11 @@
 @import "custom.bulma.scss";
 @import "sustaining_members.scss";
 
+
+html {
+  scroll-padding-top: 120px; /* height of your fixed header */
+}
+
 body {
   color: $text-primary1;
   font-weight: 300;
@@ -336,4 +341,13 @@ a.is-active > span {
 
 a.heading-anchor {
   visibility: hidden;
+}
+
+h1:hover > a.heading-anchor,
+h2:hover > a.heading-anchor,
+h3:hover > a.heading-anchor,
+h4:hover > a.heading-anchor,
+h5:hover > a.heading-anchor,
+h6:hover > a.heading-anchor {
+  visibility: visible;
 }

--- a/qgis-app/static/style/scss/style.scss
+++ b/qgis-app/static/style/scss/style.scss
@@ -333,3 +333,7 @@ a.is-active > span {
 .choices__list--dropdown, .choices__list[aria-expanded] {
   z-index: 10 !important;
 }
+
+a.heading-anchor {
+  visibility: hidden;
+}


### PR DESCRIPTION
Fix for #112 

- Hide the anchor in the sustaining members section

![image](https://github.com/user-attachments/assets/75d3a4f6-41e8-4fe7-94ea-d1982a4f8e35)
