### PR TITLE
plugins.xml: remove the "version" child element

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugins.xml
+++ b/qgis-app/plugins/templates/plugins/plugins.xml
@@ -4,7 +4,6 @@
     {% for version in object_list %}<pyqgis_plugin name="{{version.plugin.name}}" version="{{ version.version }}" plugin_id="{{version.plugin.id }}">
         <description><![CDATA[{{ version.plugin.description }}]]></description>
         <about>{% if version.plugin.about %}<![CDATA[{{ version.plugin.about }}]]>{% endif %}</about>
-        <version>{{ version.version }}</version>
         <trusted>{{ version.is_trusted }}</trusted>
         <qgis_minimum_version>{{ version.min_qg_version }}</qgis_minimum_version>
         <qgis_maximum_version>{{ version.max_qg_version }}</qgis_maximum_version>


### PR DESCRIPTION
QGIS only uses the "version" attribute of the "pyqgis_plugin" element.

See https://github.com/qgis/QGIS/blob/261ee7da134bc54b742dd9186ed10da1437d869a/python/pyplugin_installer/installer_data.py#L511.