### PR TITLE
Fix CSS class name for table container in plugin detail template

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugin_detail.html
+++ b/qgis-app/plugins/templates/plugins/plugin_detail.html
@@ -419,7 +419,7 @@
                 </div>
                 <div class="tab-pane" id="plugin-versions">
                     {% if object.pluginversion_set.count %}
-                    <div class="table_container">
+                    <div class="table-container">
                         <table class="table versions-list-table">
                             <thead>
                                 <tr>


### PR DESCRIPTION
Fix CSS class name for plugin versions table to prevent overflow

<img width="376" alt="image" src="https://github.com/user-attachments/assets/db8e8ea8-366c-4a30-abac-60ca6f42e0b5" />
