### PR TITLE
Resolve table button overflow issue

### DIFF
--- a/qgis-app/static/style/scss/custom.bulma.scss
+++ b/qgis-app/static/style/scss/custom.bulma.scss
@@ -182,3 +182,17 @@ $notification-radius: $corner-radius;
 @import "bulma/layout/_all.sass";
 @import "bulma/helpers/_all.sass";
 @import "bulma/form/_all.sass";
+
+.versions-list-table {
+  thead {
+    z-index: 30;
+  }
+  tbody {
+    .button,
+    button,
+    .icon,
+    i {
+      z-index: 1 !important;
+    }
+  }
+}


### PR DESCRIPTION
Resolves an issue where buttons in the "Manage" column overflow when scrolling on mobile devices.

<img width="376" alt="Screenshot 2025-06-11 at 2 04 39" src="https://github.com/user-attachments/assets/363c07d4-4684-492a-9890-27ce4964a605" />
