### PR TITLE
Fix docs_publish.html ("Upload a plugin")

### DIFF
--- a/qgis-app/templates/flatpages/docs_publish.html
+++ b/qgis-app/templates/flatpages/docs_publish.html
@@ -11,7 +11,7 @@
     </li>
     <li>
       Go to <a title="Repo" href="/plugins/">QGIS plugin repo</a> and click on
-      <a title="Share" href="/plugins/add/">Share a plugin</a>.
+      <a title="Share" href="/plugins/add/">Upload a plugin</a>.
     </li>
     <li>For a prompt approval of the plugin read the following guidelines</li>
   </ul>


### PR DESCRIPTION
The name of the "button" is currently "Upload a plugin", not "Share a plugin".