### PR TITLE
Comment out featured plugin functionality

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugin_detail.html
+++ b/qgis-app/plugins/templates/plugins/plugin_detail.html
@@ -282,7 +282,7 @@
                             <span>{% trans "Tokens" %}</span>
                         </a>
                     </p>
-                    {% if user.is_staff %}
+                    {% comment %} {% if user.is_staff %}
                         <p class="control">
                             {% if object.featured %}
                                 <button class="button is-warning" type="submit" name="unset_featured" value="unset_featured" id="unset_featured">
@@ -300,7 +300,7 @@
                                 </button>
                             {% endif %}
                         </p>
-                    {% endif %}
+                    {% endif %} {% endcomment %}
                     {% if user.is_staff or user in object.editors %}
                         <p class="control">
                             <a class="button is-danger" href="{% url "plugin_delete" object.package_name %}">

--- a/qgis-app/plugins/urls.py
+++ b/qgis-app/plugins/urls.py
@@ -75,18 +75,19 @@ urlpatterns = [
         {},
         name="plugin_token_delete",
     ),
-    url(
-        r"^(?P<package_name>[A-Za-z][A-Za-z0-9-_]+)/set_featured/$",
-        plugin_set_featured,
-        {},
-        name="plugin_set_featured",
-    ),
-    url(
-        r"^(?P<package_name>[A-Za-z][A-Za-z0-9-_]+)/unset_featured/$",
-        plugin_unset_featured,
-        {},
-        name="plugin_unset_featured",
-    ),
+    # Uncomment the following lines when ready to use featured plugins
+    # url(
+    #     r"^(?P<package_name>[A-Za-z][A-Za-z0-9-_]+)/set_featured/$",
+    #     plugin_set_featured,
+    #     {},
+    #     name="plugin_set_featured",
+    # ),
+    # url(
+    #     r"^(?P<package_name>[A-Za-z][A-Za-z0-9-_]+)/unset_featured/$",
+    #     plugin_unset_featured,
+    #     {},
+    #     name="plugin_unset_featured",
+    # ),
     url(
         r"^user/(?P<username>\w+)/admin$",
         UserDetailsPluginsList.as_view(),
@@ -110,17 +111,18 @@ urlpatterns = [
         ),
         name="my_plugins",
     ),
-    url(
-        r"^featured/$",
-        PluginsList.as_view(
-            queryset=Plugin.featured_objects.all(),
-            additional_context={
-                "title": _("Featured Plugins"),
-                "description": _("List of approved plugins with the 'featured' flags set."),
-            },
-        ),
-        name="featured_plugins",
-    ),
+    # Uncomment the following lines when ready to use featured plugins
+    # url(
+    #     r"^featured/$",
+    #     PluginsList.as_view(
+    #         queryset=Plugin.featured_objects.all(),
+    #         additional_context={
+    #             "title": _("Featured Plugins"),
+    #             "description": _("List of approved plugins with the 'featured' flags set."),
+    #         },
+    #     ),
+    #     name="featured_plugins",
+    # ),
     url(r"^user/(?P<username>\w+)/$", UserPluginsList.as_view(), name="user_plugins"),
     url(
         r"^server/$",

--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -218,11 +218,13 @@ NEWS_MENU = [
 
 # Featured, popular, most downloaded, most voted, most rated
 TOP_MENU = [
-    {
-        'name': 'Featured',
-        'url': '/plugins/featured/',
-        'order': 0,
-    },
+    # Hidden for now, as we didn't set rules for featured plugins
+    # Uncomment the following lines when ready to use featured plugins
+    # {
+    #     'name': 'Featured',
+    #     'url': '/plugins/featured/',
+    #     'order': 0,
+    # },
     {
         'name': 'Popular',
         'url': '/plugins/popular/',


### PR DESCRIPTION
Fix for #134 

This will hide the 'Featured' plugins menu, page, and set/unset featured buttons. We can just uncomment these line when we have a decision for https://github.com/qgis/QGIS-Plugins-Website/issues/79

<img width="1666" height="1848" alt="image" src="https://github.com/user-attachments/assets/32450340-45ae-4593-a7f3-22b58b0e18d9" />
