### PR TITLE
Add support for QGIS 4 ready plugins and update navigation

### DIFF
--- a/qgis-app/homepage.py
+++ b/qgis-app/homepage.py
@@ -13,6 +13,7 @@ def homepage(request):
     latest = Plugin.latest_objects.all()[:5]
     featured = Plugin.featured_objects.all()[:5]
     popular = Plugin.popular_objects.all()[:5]
+    new_qgis_ready = Plugin.new_qgis_ready_objects.all()[:5]
     try:
         content = FlatPage.objects.get(url="/").content
     except FlatPage.DoesNotExist:
@@ -25,6 +26,7 @@ def homepage(request):
             "featured": featured,
             "latest": latest,
             "popular": popular,
+            "new_qgis_ready": new_qgis_ready,
             "content": content,
             "title": "QGIS plugins web portal"
         },

--- a/qgis-app/plugins/models.py
+++ b/qgis-app/plugins/models.py
@@ -102,6 +102,26 @@ class ExperimentalPlugins(BasePluginManager):
             .distinct()
         )
 
+class NewQgisMajorVersionReadyPlugins(BasePluginManager):
+    """
+    Shows only public plugins: i.e. those with "approved" flag set
+    and with one version that is compatible with QGIS 4.x
+    This is determined by checking if the max_qg_version is greater than or equal to "4.0".
+    This manager filters out deprecated plugins as well.
+    """
+
+    def get_queryset(self):
+        return (
+            super(NewQgisMajorVersionReadyPlugins, self)
+            .get_queryset()
+            .filter(
+                pluginversion__approved=True,
+                pluginversion__max_qg_version__gte="4.0",
+                deprecated=False
+            )
+            .distinct()
+            .order_by("-created_on")
+        )
 
 class FeaturedPlugins(BasePluginManager):
     """
@@ -533,6 +553,7 @@ class Plugin(models.Model):
     approved_objects = ApprovedPlugins()
     stable_objects = StablePlugins()
     experimental_objects = ExperimentalPlugins()
+    new_qgis_ready_objects = NewQgisMajorVersionReadyPlugins()
     featured_objects = FeaturedPlugins()
     fresh_objects = FreshPlugins()
     latest_objects = LatestPlugins()

--- a/qgis-app/plugins/templates/plugins/plugin_sidebar.html
+++ b/qgis-app/plugins/templates/plugins/plugin_sidebar.html
@@ -38,6 +38,11 @@
                     <li class="has-child {% if request.path == entry.url %}is-active{% endif %}">
                       <a href="{{ entry.url }}">
                         {{ entry.name }}
+                          {% if entry.is_highlighted %}
+                            <span class="tag is-success is-rounded is-size-7 ml-1">
+                              {% trans "New" %}
+                            </span>
+                          {% endif %}
                       </a>
                     </li>
                     {% endfor %}

--- a/qgis-app/plugins/urls.py
+++ b/qgis-app/plugins/urls.py
@@ -202,6 +202,18 @@ urlpatterns = [
         name="experimental_plugins",
     ),
     url(
+        r"^new_qgis_ready/$",
+        PluginsList.as_view(
+            queryset=Plugin.new_qgis_ready_objects.all(),
+            additional_context={
+                "title": _("QGIS 4 Ready Plugins"),
+                "description": _("List of approved plugins that are ready for QGIS 4."),
+            },
+        ),
+        name="new_qgis_ready_plugins",
+    ),
+
+    url(
         r"^popular/$",
         PluginsList.as_view(
             queryset=Plugin.popular_objects.all(),

--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -205,14 +205,20 @@ WEBPACK_LOADER = {
 # News and Updated menus
 NEWS_MENU = [
     {
-        'name': 'New',
-        'url': '/plugins/fresh/',
+        'name': 'QGIS 4 Ready',
+        'url': '/plugins/new_qgis_ready/',
         'order': 0,
+        'is_highlighted': True,
     },
     {
-        'name': 'Updated',
-        'url': '/plugins/latest/',
+        'name': 'New Plugins',
+        'url': '/plugins/fresh/',
         'order': 1,
+    },
+    {
+        'name': 'Updated Plugins',
+        'url': '/plugins/latest/',
+        'order': 2,
     },
 ]
 

--- a/qgis-app/static/config/navigation.json
+++ b/qgis-app/static/config/navigation.json
@@ -29,14 +29,21 @@
           {
             "type": "second-menu",
             "settings": {
-              "name": "New",
+              "name": "QGIS 4 Ready",
+              "href": "/plugins/new_qgis_ready/"
+            }
+          },
+          {
+            "type": "second-menu",
+            "settings": {
+              "name": "New Plugins",
               "href": "/plugins/fresh/"
             }
           },
           {
             "type": "second-menu",
             "settings": {
-              "name": "Updated",
+              "name": "Updated Plugins",
               "href": "/plugins/latest/"
             }
           },

--- a/qgis-app/templates/base.html
+++ b/qgis-app/templates/base.html
@@ -45,7 +45,7 @@
     ></qg-top-nav>
     {% include 'layouts/header.html' %}
     {% block pagetitle %}{% endblock %}
-    <section class="section" style="margin-top: 7rem;">
+    <section class="section" style="margin-top: 5rem;">
         <div class="container content">
             <div class="columns is-multiline is-centered">
                 <div class="column is-3">

--- a/qgis-app/templates/flatpages/home_leftbar.html
+++ b/qgis-app/templates/flatpages/home_leftbar.html
@@ -1,6 +1,42 @@
 {% load i18n plugins_tagcloud thumbnail plugin_utils static %}
 <nav id="sidebar" class="sidebar">
     <ul class="content-wrapper">
+        {% if new_qgis_ready %}
+        <li>
+            <div class="has-child">
+                <a href="{% url 'new_qgis_ready_plugins' %}" class="has-text-weight-semibold has-text-success">
+                    <i class="fa-solid fa-cubes is-size-5 mr-3"></i>
+                    {% trans "QGIS 4 ready" %}
+                    <span class="tag is-success is-rounded is-small ml-2">{% trans "New" %}</span>
+                </a>
+            </div>
+            <ul>
+                {% for plugin in new_qgis_ready %}
+                <li>
+                    <a href="{% url "plugin_detail" plugin.package_name %}">
+                        <span class="mr-2">
+                            {% if plugin.icon and plugin.icon.file and plugin.icon|is_image_valid %}
+                                {% with image_extension=plugin.icon.name|file_extension %}
+                                    {% if image_extension == 'svg' %}
+                                        <img class="pull-right plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ plugin.icon.url }}" width="16" height="16" />
+                                    {% else %}
+                                        {% thumbnail plugin.icon "16x16" format="PNG" as im %}
+                                            <img class="plugin-icon" alt="{% trans "Plugin icon" %}" src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" />
+                                        {% endthumbnail %}
+                                    {% endif %}
+                                {% endwith %}
+                            {% else %}
+                                <img height="16" width="16" class="plugin-icon" src="{% static "images/qgis-icon-16x16.png" %}" alt="{% trans "Plugin icon" %}" />
+                            {% endif %}
+                        </span>
+                        {{ plugin.name }}
+                    </a>
+                </li>
+                {% endfor %}
+            </ul>
+        </li>
+        <hr/>
+        {% endif %}
         {% if featured %}
             <li>
                 <div class="has-child">
@@ -34,9 +70,9 @@
                     {% endfor %}
                 </ul>
             </li>
+        <hr/>
         {% endif %}
         {% if latest %}
-        <hr/>
         <li>
             <div class="has-child">
                 <a href="{% url 'latest_plugins'%}" class="has-text-weight-semibold has-text-info">

--- a/qgis-app/templates/layouts/header.html
+++ b/qgis-app/templates/layouts/header.html
@@ -48,6 +48,11 @@
                                             {% for entry in subitem.submenu %}
                                                 <a class="navbar-item has-text-weight-semibold is-size-7 ml-1 mr-1" href="{{ entry.url }}">
                                                     {{ entry.name }}
+                                                    {% if entry.is_highlighted %}
+                                                        <span class="tag is-success is-rounded is-size-7 ml-1">
+                                                        {% trans "New" %}
+                                                        </span>
+                                                    {% endif %}
                                                 </a>
                                             {% endfor %}
                                             {% if not forloop.last %}


### PR DESCRIPTION
Closes #132 

- Added menu/sidebar entries and "New" badge. @timlinux I think we could also add this badge to newly created features (Hub screenshot for example) to make them stand out and more visible to contributors. We can remove them after a while. 
- Added a list that shows only public plugins: i.e. those with "approved" flag set and with one version that is compatible with QGIS 4.x. This is determined by checking if the max_qg_version is greater than or equal to "4.0". This manager also filters out deprecated plugins.

<img width="2418" height="1782" alt="image" src="https://github.com/user-attachments/assets/ec7b587a-42b5-4bf9-9efb-0cb33b5eb72c" />

<img width="2418" height="1940" alt="image" src="https://github.com/user-attachments/assets/d9205343-38ef-4f98-acb3-d343ad3bffc1" />

