### PR TITLE
Add notes on how to rename a plugin

### DIFF
--- a/qgis-app/docs.py
+++ b/qgis-app/docs.py
@@ -22,3 +22,14 @@ def docs_approval(request):
         "flatpages/docs_approval.html",
         {},
     )
+
+
+def docs_faq(request):
+    """
+    Renders the docs_faq page
+    """
+    return render(
+        request,
+        "flatpages/docs_faq.html",
+        {},
+    )

--- a/qgis-app/plugins/templates/plugins/plugin_sidebar.html
+++ b/qgis-app/plugins/templates/plugins/plugin_sidebar.html
@@ -89,6 +89,12 @@
             Approval process
           </a>
         </li>
+        {% url 'docs_faq' as docs_faq_url %}
+        <li class="has-child {% if request.path == docs_faq_url %}is-active{% endif %}">
+          <a href="{{ docs_faq_url }}">
+            FAQ
+          </a>
+        </li>
       </ul>
     </li>
     <li>

--- a/qgis-app/templates/flatpages/docs_faq.html
+++ b/qgis-app/templates/flatpages/docs_faq.html
@@ -1,0 +1,29 @@
+{% extends 'flatpages/docs.html' %}
+
+{% block content %}
+<div class="responsive-content">
+  <h1>Frequently Asked Questions</h1>
+
+  <h2>How do I rename an existing plugin?</h2>
+
+  <h3>Changing the plugin display name</h3>
+  <p>
+    At present, the plugin display name can only be changed via the administration interface, and it requires additional verification. 
+    To request a name change for an existing QGIS plugin, please contact the QGIS Plugin Administration team by emailing 
+    <a href="mailto:tim@katoza.com">tim@katoza.com</a> and <a href="mailto:lova@kartoza.com">lova@kartoza.com</a> from the plugin author's email address.
+  </p>
+
+  <h3>Renaming the directory (also known as <code>package_name</code>)</h3>
+  <p>
+    This functionality was previously requested but has since been discontinued. 
+    It is strongly recommended to keep the original plugin identifier (directory name) to avoid compatibility issues. 
+    Changing the <code>package_name</code> may cause QGIS to treat the plugin as uninstalled, 
+    which can result in errors during installation.
+  </p>
+  <p>
+    More details can be found in the discussion 
+    <a href="https://github.com/qgis/QGIS-Django/pull/271#issuecomment-1794858448">here</a>.
+  </p>
+
+</div>
+{% endblock %}

--- a/qgis-app/templates/flatpages/home_content.html
+++ b/qgis-app/templates/flatpages/home_content.html
@@ -54,11 +54,19 @@
         batch, and more
       </li>
       <li>
-        Learn how to
-        <a title="Learn how to publish your plugins" href="/docs/publish"
-          >publish your plugins</a
-        >
-      </li>
-    </ul>
+        Visit the documentation to learn:
+        <ul>
+          <li>
+            How to <a href="/docs/publish">publish your plugins</a> on the
+            repository.
+          </li>
+          <li>
+            How to <a href="/docs/approval">get your plugin approved</a> for
+            publication.
+          </li>
+          <li>
+            How to rename an existing plugin in the <a href="/docs/faq">FAQ</a> section.
+          </li>
+        </ul>
   </div>
 </div>

--- a/qgis-app/urls.py
+++ b/qgis-app/urls.py
@@ -14,7 +14,7 @@ from drf_yasg.views import get_schema_view
 # to find users app views
 # from users.views import *
 from homepage import homepage
-from docs import docs_publish, docs_approval
+from docs import docs_publish, docs_approval, docs_faq
 from rest_framework import permissions
 
 admin.autodiscover()
@@ -78,6 +78,7 @@ urlpatterns += [
     url(r"^$", homepage, name="homepage"),
     url(r"^docs/publish", docs_publish, name="docs_publish"),
     url(r"^docs/approval", docs_approval, name="docs_approval"),
+    url(r"^docs/faq", docs_faq, name="docs_faq"),
 ]
 
 


### PR DESCRIPTION
Closes #150 

Cc @NyakudyaA

Added a new page to the documentation question for FAQ:

- The question here would be "How do I rename an existing plugin?"
- Add Tim and Lova's email addresses
- Minor update to the homepage

<img width="1445" height="715" alt="image" src="https://github.com/user-attachments/assets/54a900e0-558d-408e-841f-8feb1ccd60d3" />

<img width="1422" height="1009" alt="image" src="https://github.com/user-attachments/assets/d1083c82-49ec-4f3a-b2e2-2e396c058d8e" />

