### PR TITLE
Add a feature for version bulk delete

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: 'static/'
 repos:
   # Fix end of files
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -15,23 +15,23 @@ repos:
 
   # Remove unused imports/variables
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v2.3.1
     hooks:
       - id: autoflake
         args:
           - "--in-place"
           - "--remove-unused-variables"
-          # - "--remove-all-unused-imports"
+          - "--remove-all-unused-imports"
 
   # Sort imports
   - repo: https://github.com/pycqa/isort
-    rev: "5.7.0"
+    rev: "6.0.1"
     hooks:
       - id: isort
         args: ["--profile", "black"]
 
   # Black formatting
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 25.1.0
     hooks:
       - id: black

--- a/qgis-app/plugins/templates/plugins/plugin_detail.html
+++ b/qgis-app/plugins/templates/plugins/plugin_detail.html
@@ -80,6 +80,8 @@
             $(window).scrollTop(0);
         });
 
+        updateBulkDeleteButton();
+
     });
 
     function copyToClipBoard(plugin_id) {
@@ -115,8 +117,8 @@
         var columnDefs;
         if (isUserAllowedToManage()) {
             columnDefsValue = [
-                { sortable: false, targets: [-1, -3] },
-                { searchable: false, targets: [1, 2, 5, 7, -1] },
+                { sortable: false, targets: [0, -1, -3] },
+                { searchable: false, targets: [0, 1, 2, 5, 7, -1] },
                 { type: 'date', targets: [-2], orderDataType: 'dom-data-order'}
             ];
         } else {
@@ -133,6 +135,27 @@
             order: [[-1, 'desc']]
         });
         });
+    
+    function toggleAllVersions(source) {
+        const checkboxes = document.querySelectorAll('.version-checkbox');
+        checkboxes.forEach(cb => {
+            cb.checked = source.checked;
+        });
+        updateBulkDeleteButton();
+    }
+
+    function updateBulkDeleteButton() {
+        const checkboxes = document.querySelectorAll('.version-checkbox:checked');
+        const btn = document.getElementById('bulk-delete-btn');
+        if (btn) {
+            document.getElementById('selected-count').innerText = checkboxes.length;
+            if (checkboxes.length > 0) {
+                btn.disabled = false;
+            } else {
+                btn.disabled = true;
+            }
+        }
+    }
 </script>
 {% endblock %}
 {% block extracss %}
@@ -468,85 +491,105 @@
                 </div>
                 <div class="tab-pane" id="plugin-versions">
                     {% if object.pluginversion_set.count %}
-                      <div class="table-container">
-                        <table id="plugin-versions-table" class="table versions-list-table">
-                            <thead>
-                                <tr>
-                                    <th>{% trans "Version" %}</th>
-                                    {% if not user.is_anonymous %}<th title="{% trans "Approved" %}"><i class="fa-solid fa-plug-circle-check"></i></th>{% endif %}
-                                    <th  title="{% trans "Experimental" %}"><i class="fa-solid fa-flask"></i></th>
-                                    <th title="{% trans "Min QGIS version" %}">{% trans "QGIS >=" %}</th>
-                                    <th title="{% trans "Max QGIS version" %}">{% trans "QGIS <=" %}</th>
-                                    <th title="{% trans "Downloads" %}"><i class="fa-solid fa-download"></i></th>
-                                    <th title="{% trans "Uploaded by" %}"><i class="fa-solid fa-user"></i></th>
-                                    <th title="{% trans "Date" %}"><i class="fa-regular fa-calendar"></i> {% trans "Date" %}</th>
-                                    {% if user.is_staff or user in object.approvers or user in object.editors %}<th title="{% trans "Manage" %}"><i class="fa-solid fa-gear"></i> {% trans "Manage" %}</th>{% endif %}
-                                </tr>
-                            </thead>
-                            <tbody>
-                            {% for version in plugin_versions_sorted %}
-                                {% if version.approved or not user.is_anonymous %}
-                                <tr onclick="window.location.href='{% url "version_detail" object.package_name version.version %}';">
-                                    <td class="has-text-centered">
-                                        <a href="{% url 'version_detail' object.package_name version.version %}">{{ version.version }}</a>
-                                    </td>
-                                    {% if not user.is_anonymous %}
-                                    <td class="has-text-centered">
-                                        {% if version.approved %}
-                                            <i class="fas fa-check-circle has-text-success"></i>
-                                        {% else %}
-                                            <i class="fas fa-times-circle has-text-danger"></i>
-                                        {% endif %}
-                                    </td>
-                                    {% endif %}
-                                    <td class="has-text-centered">
-                                        {% if version.experimental %}
-                                            <i class="fas fa-flask has-text-warning"></i>
-                                        {% else %}
-                                            -
-                                        {% endif %}
-                                    </td>
-                                    <td class="has-text-centered">{{ version.min_qg_version }}</td>
-                                    <td class="has-text-centered">{{ version.max_qg_version }}</td>
-                                    <td class="downloads">{{ version.downloads }}</td>
-                                    {% if version.is_from_token %}
-                                    <td class="has-text-centered">Token {{ version.token.description|default:"" }}</td>
-                                    {% else %}
-                                    <td class="has-text-centered"><a href="{% url "user_details" version.created_by.username %}">{{ version.created_by }}</a></td>
-                                    {% endif %}
-                                    <td class="has-text-centered" data-order="{{ version.created_on.isoformat }}">{{ version.created_on|local_timezone }}</td>
-                                    {% if user.is_staff or user in version.plugin.approvers or user in version.plugin.editors %}
-                                    <td class="has-text-centered" style="min-width: 200px;">
-                                        <form method="post" action="{% url "version_manage" object.package_name version.version %}">{% csrf_token %}
-                                        {% if user.is_staff or user in version.plugin.approvers %}
-                                            {% if not version.approved %}
-                                            <button class="button is-success is-small is-outlined" type="submit" name="version_approve" title="{% trans "Approve" %}">
-                                                <i class="fas fa-thumbs-up"></i>
-                                            </button>
-                                            {% else %}
-                                            <button class="button is-warning is-small is-outlined" type="submit" name="version_unapprove" title="{% trans "Unapprove" %}">
-                                                <i class="fas fa-thumbs-down"></i></button>
-                                            {% endif %}
-                                        {% endif %}
-                                        <a class="button is-small is-outlined {% if version.feedback|feedbacks_not_completed|length >= 1 %}is-warning{% else %}is-success{% endif %}" href="{% url "version_feedback" object.package_name version.version %}" title="{% trans "Feedback" %}">
-                                            <i class="fas fa-comments"></i>
-                                            {% if version.feedback|feedbacks_not_completed|length >= 2 %}
-                                                {{ version.feedback|feedbacks_not_completed|length }}
-                                            {% endif %}
-                                        </a>
+                    <form id="bulk-delete-form" method="post" action="{% url "versions_bulk_delete" object.package_name %}">
+                        {% csrf_token %}
+
+                        <div class="table-container">
+                            <table id="plugin-versions-table" class="table versions-list-table">
+                                <thead>
+                                    <tr>
                                         {% if user.is_staff or user in version.plugin.editors %}
-                                        <a class="button is-success is-small is-outlined" href="{% url "version_update" object.package_name version.version %}" title="{% trans "Edit" %}"><i class="fas fa-pencil"></i></a>
-                                        <a class="button is-danger is-small is-outlined" href="{% url "version_delete" object.package_name version.version %}" title="{% trans "Delete" %}"><i class="fas fa-remove"></i></a>
+                                            <th><input type="checkbox" id="select-all-versions" onclick="toggleAllVersions(this)"></th>
                                         {% endif %}
-                                        </form>
-                                    </td>
+                                        <th>{% trans "Version" %}</th>
+                                        {% if not user.is_anonymous %}<th title="{% trans "Approved" %}"><i class="fa-solid fa-plug-circle-check"></i></th>{% endif %}
+                                        <th  title="{% trans "Experimental" %}"><i class="fa-solid fa-flask"></i></th>
+                                        <th title="{% trans "Min QGIS version" %}">{% trans "QGIS >=" %}</th>
+                                        <th title="{% trans "Max QGIS version" %}">{% trans "QGIS <=" %}</th>
+                                        <th title="{% trans "Downloads" %}"><i class="fa-solid fa-download"></i></th>
+                                        <th title="{% trans "Uploaded by" %}"><i class="fa-solid fa-user"></i></th>
+                                        <th title="{% trans "Date" %}"><i class="fa-regular fa-calendar"></i> {% trans "Date" %}</th>
+                                        {% if user.is_staff or user in object.approvers or user in object.editors %}<th title="{% trans "Manage" %}"><i class="fa-solid fa-gear"></i> {% trans "Manage" %}</th>{% endif %}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                {% for version in plugin_versions_sorted %}
+                                    {% if version.approved or not user.is_anonymous %}
+                                    <tr>
+                                        {% if user.is_staff or user in version.plugin.editors %}
+                                            <td class="has-text-centered">
+                                                <input type="checkbox" class="version-checkbox" name="selected_versions" value="{{ version.pk }}" onclick="updateBulkDeleteButton()">
+                                            </td>
+                                        {% endif %}
+                                        <td class="has-text-centered">
+                                            <a href="{% url 'version_detail' object.package_name version.version %}">{{ version.version }}</a>
+                                        </td>
+                                        {% if not user.is_anonymous %}
+                                        <td class="has-text-centered">
+                                            {% if version.approved %}
+                                                <i class="fas fa-check-circle has-text-success"></i>
+                                            {% else %}
+                                                <i class="fas fa-times-circle has-text-danger"></i>
+                                            {% endif %}
+                                        </td>
+                                        {% endif %}
+                                        <td class="has-text-centered">
+                                            {% if version.experimental %}
+                                                <i class="fas fa-flask has-text-warning"></i>
+                                            {% else %}
+                                                -
+                                            {% endif %}
+                                        </td>
+                                        <td class="has-text-centered">{{ version.min_qg_version }}</td>
+                                        <td class="has-text-centered">{{ version.max_qg_version }}</td>
+                                        <td class="downloads">{{ version.downloads }}</td>
+                                        {% if version.is_from_token %}
+                                        <td class="has-text-centered">Token {{ version.token.description|default:"" }}</td>
+                                        {% else %}
+                                        <td class="has-text-centered"><a href="{% url "user_details" version.created_by.username %}">{{ version.created_by }}</a></td>
+                                        {% endif %}
+                                        <td class="has-text-centered" data-order="{{ version.created_on.isoformat }}">{{ version.created_on|local_timezone }}</td>
+                                        {% if user.is_staff or user in version.plugin.approvers or user in version.plugin.editors %}
+                                        <td class="has-text-centered" style="min-width: 200px;">
+                                            <form method="post" action="{% url "version_manage" object.package_name version.version %}">{% csrf_token %}
+                                            {% if user.is_staff or user in version.plugin.approvers %}
+                                                {% if not version.approved %}
+                                                <button class="button is-success is-small is-outlined" type="submit" name="version_approve" title="{% trans "Approve" %}">
+                                                    <i class="fas fa-thumbs-up"></i>
+                                                </button>
+                                                {% else %}
+                                                <button class="button is-warning is-small is-outlined" type="submit" name="version_unapprove" title="{% trans "Unapprove" %}">
+                                                    <i class="fas fa-thumbs-down"></i></button>
+                                                {% endif %}
+                                            {% endif %}
+                                            <a class="button is-small is-outlined {% if version.feedback|feedbacks_not_completed|length >= 1 %}is-warning{% else %}is-success{% endif %}" href="{% url "version_feedback" object.package_name version.version %}" title="{% trans "Feedback" %}">
+                                                <i class="fas fa-comments"></i>
+                                                {% if version.feedback|feedbacks_not_completed|length >= 2 %}
+                                                    {{ version.feedback|feedbacks_not_completed|length }}
+                                                {% endif %}
+                                            </a>
+                                            {% if user.is_staff or user in version.plugin.editors %}
+                                            <a class="button is-success is-small is-outlined" href="{% url "version_update" object.package_name version.version %}" title="{% trans "Edit" %}"><i class="fas fa-pencil"></i></a>
+                                            <a class="button is-danger is-small is-outlined" href="{% url "version_delete" object.package_name version.version %}" title="{% trans "Delete" %}"><i class="fas fa-remove"></i></a>
+                                            {% endif %}
+                                            </form>
+                                        </td>
+                                        {% endif %}
+                                    </tr>
                                     {% endif %}
-                                </tr>
-                                {% endif %}
-                            {% endfor %}
-                            </tbody>
-                        </table>
-                    </div>
+                                {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                        {% if user.is_staff or user in object.editors %}
+                            <button id="bulk-delete-btn" class="button is-danger is-light" type="submit" disabled>
+                                <span class="icon">
+                                    <i class="fas fa-trash"></i>
+                                </span>
+                                <span>{% trans "Delete selected versions:" %} <span id="selected-count">0</span></span>
+                            </button>
+                        {% endif %}
+                    </form>
                     {% endif %}
                 </div> 
                 {% if user.is_staff or user in object.editors %}

--- a/qgis-app/plugins/templates/plugins/versions_bulk_delete_confirm.html
+++ b/qgis-app/plugins/templates/plugins/versions_bulk_delete_confirm.html
@@ -1,0 +1,60 @@
+{% extends 'plugins/plugin_base.html' %}{% load i18n %}
+{% block content %}
+    <h3>{% blocktrans with plugin.name as plugin_name %}Delete selected versions of "{{ plugin_name }}"{% endblocktrans %}</h3>
+    <form action="" method="post">{% csrf_token %}
+        <div class="notification is-danger is-light">
+            {% trans "You asked to delete the following versions. The versions will be permanently deleted and this action cannot be undone. Please confirm." %}
+        </div>
+        <div class="table-container mb-4">
+            <table class="table is-fullwidth is-striped is-hoverable">
+                <thead>
+                    <tr>
+                        <th>{% trans "Version" %}</th>
+                        <th>{% trans "Experimental" %}</th>
+                        <th>{% trans "Min QGIS version" %}</th>
+                        <th>{% trans "Max QGIS version" %}</th>
+                        <th>{% trans "Downloads" %}</th>
+                        <th>{% trans "Uploaded by" %}</th>
+                        <th>{% trans "Date" %}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for version in versions %}
+                    <tr>
+                        <td><span class="has-text-weight-bold">{{ version.version }}</span></td>
+                        <td class="has-text-centered">
+                            {% if version.experimental %}
+                                <i class="fas fa-flask has-text-warning"></i>
+                            {% else %}
+                                -
+                            {% endif %}
+                        </td>
+                        <td class="has-text-centered">{{ version.min_qg_version }}</td>
+                        <td class="has-text-centered">{{ version.max_qg_version }}</td>
+                        <td class="has-text-centered">{{ version.downloads }}</td>
+                        <td class="has-text-centered">
+                            {% if version.is_from_token %}
+                                Token {{ version.token.description|default:"" }}
+                            {% else %}
+                                {{ version.created_by }}
+                            {% endif %}
+                        </td>
+                        <td class="has-text-centered">{{ version.created_on|date:'Y-m-d' }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% for version in versions %}
+            <input type="hidden" name="selected_versions" value="{{ version.pk }}">
+        {% endfor %}
+        <button type="submit" class="button is-danger is-light" name="confirm_bulk_delete">
+            <span class="icon"><i class="fas fa-check"></i></span>
+            <span>{% trans "Delete" %}</span>
+        </button>
+        <a class="button is-success is-outlined" href="javascript:history.back()">
+            <span class="icon"><i class="fas fa-times"></i></span>
+            <span>{% trans "Cancel" %}</span>
+        </a>
+    </form>
+{% endblock %}

--- a/qgis-app/plugins/tests/test_plugin_version_delete.py
+++ b/qgis-app/plugins/tests/test_plugin_version_delete.py
@@ -3,104 +3,122 @@ from django.test import TestCase
 from django.urls import reverse
 from plugins.models import Plugin, PluginVersion
 
-class SetupMixin:
-	fixtures = ["fixtures/auth.json"]
 
-	def setUp(self) -> None:
-		self.creator = User.objects.get(id=2)
-		self.staff = User.objects.get(id=3)
-		self.plugin = Plugin.objects.create(
-			created_by=self.creator,
-			repository="http://example.com",
-			tracker="http://example.com",
-			package_name="test-delete",
-			name="test plugin delete",
-			about="this is a test for plugin delete",
-			author="author plugin"
-		)
-		self.version1 = PluginVersion.objects.create(
-			plugin=self.plugin,
-			created_by=self.creator,
-			min_qg_version="0.0.0",
-			max_qg_version="99.99.99",
-			version="0.1",
-			approved=False,
-			external_deps="test"
-		)
-		self.version2 = PluginVersion.objects.create(
-			plugin=self.plugin,
-			created_by=self.creator,
-			min_qg_version="0.0.0",
-			max_qg_version="99.99.99",
-			version="0.2",
-			approved=False,
-			external_deps="test"
-		)
+class SetupMixin:
+    fixtures = ["fixtures/auth.json"]
+
+    def setUp(self) -> None:
+        self.creator = User.objects.get(id=2)
+        self.staff = User.objects.get(id=3)
+        self.plugin = Plugin.objects.create(
+            created_by=self.creator,
+            repository="http://example.com",
+            tracker="http://example.com",
+            package_name="test-delete",
+            name="test plugin delete",
+            about="this is a test for plugin delete",
+            author="author plugin",
+        )
+        self.version1 = PluginVersion.objects.create(
+            plugin=self.plugin,
+            created_by=self.creator,
+            min_qg_version="0.0.0",
+            max_qg_version="99.99.99",
+            version="0.1",
+            approved=False,
+            external_deps="test",
+        )
+        self.version2 = PluginVersion.objects.create(
+            plugin=self.plugin,
+            created_by=self.creator,
+            min_qg_version="0.0.0",
+            max_qg_version="99.99.99",
+            version="0.2",
+            approved=False,
+            external_deps="test",
+        )
+
 
 class TestPluginVersionDeleteView(SetupMixin, TestCase):
-	def setUp(self):
-		super().setUp()
-		self.url = reverse("version_delete", args=[self.plugin.package_name, self.version1.version])
+    def setUp(self):
+        super().setUp()
+        self.url = reverse(
+            "version_delete", args=[self.plugin.package_name, self.version1.version]
+        )
 
-	def test_delete_requires_login(self):
-		response = self.client.get(self.url)
-		self.assertEqual(response.status_code, 302)
-		self.assertIn("/accounts/login/", response.url)
+    def test_delete_requires_login(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response.url)
 
-	def test_only_editor_or_staff_can_delete(self):
-		user = User.objects.create(username="otheruser")
-		self.client.force_login(user)
-		response = self.client.get(self.url)
-		self.assertEqual(response.status_code, 200)
-		self.assertContains(response, "You cannot create or modify versions of this plugin.")
+    def test_only_editor_or_staff_can_delete(self):
+        user = User.objects.create(username="otheruser")
+        self.client.force_login(user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, "You cannot create or modify versions of this plugin."
+        )
 
-	def test_delete_confirm_page_loads(self):
-		self.client.force_login(self.creator)
-		response = self.client.get(self.url)
-		self.assertEqual(response.status_code, 200)
-		self.assertContains(response, "Delete version")
+    def test_delete_confirm_page_loads(self):
+        self.client.force_login(self.creator)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Delete version")
 
-	def test_delete_version(self):
-		self.client.force_login(self.creator)
-		response = self.client.post(self.url, {"delete_confirm": "1"})
-		self.assertRedirects(response, self.plugin.get_absolute_url())
-		self.assertFalse(PluginVersion.objects.filter(pk=self.version1.pk).exists())
+    def test_delete_version(self):
+        self.client.force_login(self.creator)
+        response = self.client.post(self.url, {"delete_confirm": "1"})
+        self.assertRedirects(response, self.plugin.get_absolute_url())
+        self.assertFalse(PluginVersion.objects.filter(pk=self.version1.pk).exists())
+
 
 class TestPluginVersionBulkDeleteView(SetupMixin, TestCase):
-	def setUp(self):
-		super().setUp()
-		self.url = reverse("versions_bulk_delete", args=[self.plugin.package_name])
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("versions_bulk_delete", args=[self.plugin.package_name])
 
-	def test_bulk_delete_requires_login(self):
-		response = self.client.post(self.url, {"selected_versions": [self.version1.pk, self.version2.pk]})
-		self.assertEqual(response.status_code, 302)
-		self.assertIn("/accounts/login/", response.url)
+    def test_bulk_delete_requires_login(self):
+        response = self.client.post(
+            self.url, {"selected_versions": [self.version1.pk, self.version2.pk]}
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response.url)
 
-	def test_only_editor_or_staff_can_bulk_delete(self):
-		user = User.objects.create(username="otheruser")
-		self.client.force_login(user)
-		response = self.client.post(self.url, {"selected_versions": [self.version1.pk, self.version2.pk]})
-		self.assertRedirects(response, self.plugin.get_absolute_url())
-		self.assertTrue(PluginVersion.objects.filter(pk=self.version1.pk).exists())
+    def test_only_editor_or_staff_can_bulk_delete(self):
+        user = User.objects.create(username="otheruser")
+        self.client.force_login(user)
+        response = self.client.post(
+            self.url, {"selected_versions": [self.version1.pk, self.version2.pk]}
+        )
+        self.assertRedirects(response, self.plugin.get_absolute_url())
+        self.assertTrue(PluginVersion.objects.filter(pk=self.version1.pk).exists())
 
-	def test_bulk_delete_confirm_page(self):
-		self.client.force_login(self.creator)
-		response = self.client.post(self.url, {"selected_versions": [self.version1.pk, self.version2.pk]})
-		self.assertEqual(response.status_code, 200)
-		self.assertContains(response, "Delete selected versions")
-		self.assertContains(response, self.version1.version)
-		self.assertContains(response, self.version2.version)
+    def test_bulk_delete_confirm_page(self):
+        self.client.force_login(self.creator)
+        response = self.client.post(
+            self.url, {"selected_versions": [self.version1.pk, self.version2.pk]}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Delete selected versions")
+        self.assertContains(response, self.version1.version)
+        self.assertContains(response, self.version2.version)
 
-	def test_bulk_delete_versions(self):
-		self.client.force_login(self.creator)
-		# First, show confirm page
-		response = self.client.post(self.url, {"selected_versions": [self.version1.pk, self.version2.pk]})
-		self.assertEqual(response.status_code, 200)
-		# Then, confirm deletion
-		response = self.client.post(self.url, {
-			"selected_versions": [self.version1.pk, self.version2.pk],
-			"confirm_bulk_delete": "1"
-		})
-		self.assertRedirects(response, self.plugin.get_absolute_url())
-		self.assertFalse(PluginVersion.objects.filter(pk=self.version1.pk).exists())
-		self.assertFalse(PluginVersion.objects.filter(pk=self.version2.pk).exists())
+    def test_bulk_delete_versions(self):
+        self.client.force_login(self.creator)
+        # First, show confirm page
+        response = self.client.post(
+            self.url, {"selected_versions": [self.version1.pk, self.version2.pk]}
+        )
+        self.assertEqual(response.status_code, 200)
+        # Then, confirm deletion
+        response = self.client.post(
+            self.url,
+            {
+                "selected_versions": [self.version1.pk, self.version2.pk],
+                "confirm_bulk_delete": "1",
+            },
+        )
+        self.assertRedirects(response, self.plugin.get_absolute_url())
+        self.assertFalse(PluginVersion.objects.filter(pk=self.version1.pk).exists())
+        self.assertFalse(PluginVersion.objects.filter(pk=self.version2.pk).exists())

--- a/qgis-app/plugins/tests/test_plugin_version_delete.py
+++ b/qgis-app/plugins/tests/test_plugin_version_delete.py
@@ -1,0 +1,106 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from plugins.models import Plugin, PluginVersion
+
+class SetupMixin:
+	fixtures = ["fixtures/auth.json"]
+
+	def setUp(self) -> None:
+		self.creator = User.objects.get(id=2)
+		self.staff = User.objects.get(id=3)
+		self.plugin = Plugin.objects.create(
+			created_by=self.creator,
+			repository="http://example.com",
+			tracker="http://example.com",
+			package_name="test-delete",
+			name="test plugin delete",
+			about="this is a test for plugin delete",
+			author="author plugin"
+		)
+		self.version1 = PluginVersion.objects.create(
+			plugin=self.plugin,
+			created_by=self.creator,
+			min_qg_version="0.0.0",
+			max_qg_version="99.99.99",
+			version="0.1",
+			approved=False,
+			external_deps="test"
+		)
+		self.version2 = PluginVersion.objects.create(
+			plugin=self.plugin,
+			created_by=self.creator,
+			min_qg_version="0.0.0",
+			max_qg_version="99.99.99",
+			version="0.2",
+			approved=False,
+			external_deps="test"
+		)
+
+class TestPluginVersionDeleteView(SetupMixin, TestCase):
+	def setUp(self):
+		super().setUp()
+		self.url = reverse("version_delete", args=[self.plugin.package_name, self.version1.version])
+
+	def test_delete_requires_login(self):
+		response = self.client.get(self.url)
+		self.assertEqual(response.status_code, 302)
+		self.assertIn("/accounts/login/", response.url)
+
+	def test_only_editor_or_staff_can_delete(self):
+		user = User.objects.create(username="otheruser")
+		self.client.force_login(user)
+		response = self.client.get(self.url)
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, "You cannot create or modify versions of this plugin.")
+
+	def test_delete_confirm_page_loads(self):
+		self.client.force_login(self.creator)
+		response = self.client.get(self.url)
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, "Delete version")
+
+	def test_delete_version(self):
+		self.client.force_login(self.creator)
+		response = self.client.post(self.url, {"delete_confirm": "1"})
+		self.assertRedirects(response, self.plugin.get_absolute_url())
+		self.assertFalse(PluginVersion.objects.filter(pk=self.version1.pk).exists())
+
+class TestPluginVersionBulkDeleteView(SetupMixin, TestCase):
+	def setUp(self):
+		super().setUp()
+		self.url = reverse("versions_bulk_delete", args=[self.plugin.package_name])
+
+	def test_bulk_delete_requires_login(self):
+		response = self.client.post(self.url, {"selected_versions": [self.version1.pk, self.version2.pk]})
+		self.assertEqual(response.status_code, 302)
+		self.assertIn("/accounts/login/", response.url)
+
+	def test_only_editor_or_staff_can_bulk_delete(self):
+		user = User.objects.create(username="otheruser")
+		self.client.force_login(user)
+		response = self.client.post(self.url, {"selected_versions": [self.version1.pk, self.version2.pk]})
+		self.assertRedirects(response, self.plugin.get_absolute_url())
+		self.assertTrue(PluginVersion.objects.filter(pk=self.version1.pk).exists())
+
+	def test_bulk_delete_confirm_page(self):
+		self.client.force_login(self.creator)
+		response = self.client.post(self.url, {"selected_versions": [self.version1.pk, self.version2.pk]})
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, "Delete selected versions")
+		self.assertContains(response, self.version1.version)
+		self.assertContains(response, self.version2.version)
+
+	def test_bulk_delete_versions(self):
+		self.client.force_login(self.creator)
+		# First, show confirm page
+		response = self.client.post(self.url, {"selected_versions": [self.version1.pk, self.version2.pk]})
+		self.assertEqual(response.status_code, 200)
+		# Then, confirm deletion
+		response = self.client.post(self.url, {
+			"selected_versions": [self.version1.pk, self.version2.pk],
+			"confirm_bulk_delete": "1"
+		})
+		self.assertRedirects(response, self.plugin.get_absolute_url())
+		self.assertFalse(PluginVersion.objects.filter(pk=self.version1.pk).exists())
+		self.assertFalse(PluginVersion.objects.filter(pk=self.version2.pk).exists())

--- a/qgis-app/plugins/urls.py
+++ b/qgis-app/plugins/urls.py
@@ -396,6 +396,12 @@ urlpatterns += [
         {},
         name="version_feedback_edit",
     ),
+    url(
+        r"^(?P<package_name>[A-Za-z][A-Za-z0-9-_]+)/bulk_delete_versions/$",
+        versions_bulk_delete,
+        {},
+        name="versions_bulk_delete",
+    ),
 ]
 
 # RPC

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -38,6 +38,8 @@ from plugins.validator import PLUGIN_REQUIRED_METADATA
 from django.contrib.gis.geoip2 import GeoIP2
 from plugins.utils import parse_remote_addr
 
+from django.template.response import TemplateResponse
+
 from rest_framework_simplejwt.token_blacklist.models import OutstandingToken
 from rest_framework_simplejwt.tokens import RefreshToken, api_settings
 from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
@@ -1404,6 +1406,38 @@ def version_delete(request, package_name, version):
 
 
 @login_required
+@transaction.atomic
+def versions_bulk_delete(request, package_name):
+    """
+    Bulk delete selected plugin versions with confirmation.
+    """
+    plugin = get_object_or_404(Plugin, package_name=package_name)
+    if not check_plugin_access(request.user, plugin):
+        messages.error(request, _("You do not have permission to delete versions for this plugin."))
+        return HttpResponseRedirect(plugin.get_absolute_url())
+
+    if request.method == "POST":
+        selected_ids = request.POST.getlist("selected_versions")
+        versions = PluginVersion.objects.filter(pk__in=selected_ids, plugin=plugin)
+        if "confirm_bulk_delete" in request.POST:
+            # Perform deletion
+            deleted_versions = list(versions)
+            versions.delete()
+            messages.success(request, _(f"Deleted {len(deleted_versions)} plugin version(s)."))
+            return HttpResponseRedirect(plugin.get_absolute_url())
+        elif selected_ids:
+            # Show confirmation page
+            return TemplateResponse(request, "plugins/versions_bulk_delete_confirm.html", {
+                "plugin": plugin,
+                "versions": versions,
+            })
+        else:
+            messages.warning(request, _("No versions selected for deletion."))
+            return HttpResponseRedirect(plugin.get_absolute_url())
+    # GET fallback
+    return HttpResponseRedirect(plugin.get_absolute_url())
+
+@login_required
 @require_POST
 def version_approve(request, package_name, version):
     """
@@ -1656,6 +1690,7 @@ def version_detail(request, package_name, version):
     plugin = get_object_or_404(Plugin, package_name=package_name)
     version = get_object_or_404(PluginVersion, plugin=plugin, version=version)
     return render(request, "plugins/version_detail.html", {"version": version})
+
 
 
 ###############################################


### PR DESCRIPTION
Closes #129 

- Allow selecting multiple/all versions with checkboxes
- Add a button to delete the selected version
- Works with the search feature
- Keep the checked plugin when navigating to another page or refreshing
- Add a confirmation page to list the versions that will be deleted
- Update unit tests

Cc @Gustry 

https://github.com/user-attachments/assets/14bb36cc-a56f-470f-8f47-aeed98516657

