### PR TITLE
Send plugin upload notifications to a specific group members only

### DIFF
--- a/qgis-app/fixtures/auth.json
+++ b/qgis-app/fixtures/auth.json
@@ -1,5 +1,13 @@
 [
     {
+        "pk": 1,
+        "model": "auth.group",
+        "fields": {
+            "name": "Plugin Notification Recipients",
+            "permissions": []
+        }
+    },
+    {
         "pk": 2,
         "model": "auth.user",
         "fields": {
@@ -51,6 +59,24 @@
             "password": "pbkdf2_sha256$150000$GJga5YEinaWz$zJAjCXccvWHNPGmoZEjvBNgm1DGkjZGA3BmTVaNAxP4=",
             "email": "staff@staff.it",
             "date_joined": "2010-11-25 07:35:20"
+        }
+    },
+    {
+        "pk": 4,
+        "model": "auth.user",
+        "fields": {
+            "username": "staff-recipient",
+            "first_name": "",
+            "last_name": "",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": true,
+            "last_login": "2024-06-01 00:00:00",
+            "groups": [1],
+            "user_permissions": [],
+            "password": "pbkdf2_sha256$150000$dummy$dummyhash",
+            "email": "staff.recipient@example.com",
+            "date_joined": "2024-06-01 00:00:00"
         }
     }
 ]

--- a/qgis-app/plugins/tests/test_plugin_update.py
+++ b/qgis-app/plugins/tests/test_plugin_update.py
@@ -91,10 +91,15 @@ class PluginUpdateTestCase(TestCase):
         self.assertEqual(self.plugin.repository, "https://github.com/")
 
         self.assertIn(
+            'staff.recipient@example.com',
+            mail.outbox[0].recipients(),
+        )
+
+        self.assertNotIn(
             'admin@admin.it',
             mail.outbox[0].recipients(),
         )
-        self.assertIn(
+        self.assertNotIn(
             'staff@staff.it',
             mail.outbox[0].recipients()
         )
@@ -148,10 +153,15 @@ class PluginUpdateTestCase(TestCase):
         self.assertEqual(self.plugin.repository, "https://github.com/")   
 
         self.assertIn(
+            'staff.recipient@example.com',
+            mail.outbox[0].recipients(),
+        )
+
+        self.assertNotIn(
             'admin@admin.it',
             mail.outbox[0].recipients(),
         )
-        self.assertIn(
+        self.assertNotIn(
             'staff@staff.it',
             mail.outbox[0].recipients()
         )

--- a/qgis-app/plugins/tests/test_plugin_upload.py
+++ b/qgis-app/plugins/tests/test_plugin_upload.py
@@ -68,10 +68,15 @@ class PluginUploadTestCase(TestCase):
         self.assertTrue(PluginVersion.objects.filter(plugin__name='Test Plugin', version='0.0.1').exists())
 
         self.assertIn(
+            'staff.recipient@example.com',
+            mail.outbox[0].recipients(),
+        )
+
+        self.assertNotIn(
             'admin@admin.it',
             mail.outbox[0].recipients(),
         )
-        self.assertIn(
+        self.assertNotIn(
             'staff@staff.it',
             mail.outbox[0].recipients()
         )

--- a/qgis-app/plugins/views.py
+++ b/qgis-app/plugins/views.py
@@ -37,6 +37,7 @@ from plugins.models import Plugin, PluginOutstandingToken, PluginVersion, Plugin
 from plugins.validator import PLUGIN_REQUIRED_METADATA
 from django.contrib.gis.geoip2 import GeoIP2
 from plugins.utils import parse_remote_addr
+from django.conf import settings
 
 from rest_framework_simplejwt.token_blacklist.models import OutstandingToken
 from rest_framework_simplejwt.tokens import RefreshToken, api_settings
@@ -53,6 +54,9 @@ except ImportError:
 staff_required = user_passes_test(lambda u: u.is_staff)
 from plugins.tasks.generate_plugins_xml import generate_plugins_xml
 
+# Plugin Notification Recipients Group Name
+NOTIFICATION_RECIPIENTS_GROUP_NAME = settings.NOTIFICATION_RECIPIENTS_GROUP_NAME
+
 
 def send_mail_wrapper(subject, message, mail_from, recipients, fail_silently=True):
     if settings.DEBUG:
@@ -63,13 +67,16 @@ def send_mail_wrapper(subject, message, mail_from, recipients, fail_silently=Tru
 
 def plugin_notify(plugin):
     """
-    Sends a message to staff on new plugins
+    Sends a message to staff that are in 
+    the notification recipients group on new plugins
     """
     recipients = [
         u.email
-        for u in User.objects.filter(is_staff=True, email__isnull=False).exclude(
-            email=""
-        )
+        for u in User.objects.filter(
+            groups__name=NOTIFICATION_RECIPIENTS_GROUP_NAME,
+            is_staff=True,
+            email__isnull=False
+        ).exclude(email="")
     ]
 
     if recipients:
@@ -96,15 +103,18 @@ def plugin_notify(plugin):
 
 def version_notify(plugin_version):
     """
-    Sends a message to staff on new plugin versions
+    Sends a message to staff that are in 
+    the notification recipients group on new plugin versions
     """
     plugin = plugin_version.plugin
 
     recipients = [
         u.email
-        for u in User.objects.filter(is_staff=True, email__isnull=False).exclude(
-            email=""
-        )
+        for u in User.objects.filter(
+            groups__name=NOTIFICATION_RECIPIENTS_GROUP_NAME,
+            is_staff=True,
+            email__isnull=False
+        ).exclude(email="")
     ]
 
     if recipients:

--- a/qgis-app/settings_docker.py
+++ b/qgis-app/settings_docker.py
@@ -179,6 +179,13 @@ PLUGIN_MAX_UPLOAD_SIZE = os.environ.get("PLUGIN_MAX_UPLOAD_SIZE", 25000000) # De
 # RPC2 Max upload size
 DATA_UPLOAD_MAX_MEMORY_SIZE = PLUGIN_MAX_UPLOAD_SIZE # same as max allowed plugin size
 
+# Plugin Notification Recipients Group Name
+# used to send notifications when a new plugin 
+# or a new version is uploaded. This group usually
+# contains the plugin approvers
+# but can be customized.
+NOTIFICATION_RECIPIENTS_GROUP_NAME = os.environ.get("NOTIFICATION_RECIPIENTS_GROUP_NAME", "Plugin Notification Recipients")
+
 # Sentry
 SENTRY_DSN = os.environ.get("SENTRY_DSN", "")
 SENTRY_RATE = os.environ.get("SENTRY_RATE", 1.0)


### PR DESCRIPTION
Closes #137 

- Requires creating a new Group from the admin page: `Plugin Notification Recipients`
- Only staff/superusers who are members of that group will receive the New plugins/versions email notification