### PR TITLE
Separate search button from input to prevent login misclicks

### DIFF
--- a/qgis-app/templates/layouts/header.html
+++ b/qgis-app/templates/layouts/header.html
@@ -83,11 +83,15 @@
 
                 </div>
                 <div class="navbar-end">
-                    <div>
-                        <div class="control has-icons-right search-control">
-                            <form action="{% url "haystack_search" %}" method="get" style="margin:0;">
+                    <div class="navbar-item">
+                        <div class="control search-control">
+                            <form action="{% url "haystack_search" %}" method="get" style="margin:0; display: flex; gap: 0.5rem; align-items: center;">
                                 <input class="input is-small"  id="id_q" name="q" type="text" placeholder="Search">
-                                <span class="icon is-right"><i class="fa-solid fa-magnifying-glass"></i></span>
+                                <button type="submit" class="button is-info is-small">
+                                    <span class="icon">
+                                        <i class="fa-solid fa-magnifying-glass"></i>
+                                    </span>
+                                </button>
                             </form>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Moved the magnifying glass icon from inside the search input field to a separate button
- Styled the search button to match the login button (same size and color)
- Added proper flex alignment to ensure visual consistency

## Problem
Users were accidentally clicking the login button when trying to search because the search input field was immediately followed by the login button with minimal spacing.

## Solution
This change creates clear visual separation by:
1. Moving the search icon into its own dedicated button
2. Styling it identically to the login button
3. Adding appropriate spacing between elements

## Test plan
- [x] Dev server started successfully
- [x] Search functionality works correctly
- [x] Search button and login button are visually distinct and properly aligned
- [x] No accidental clicks on login when attempting to search