### PR TITLE
Move login button and highlight no login required for download

### DIFF
--- a/qgis-app/templates/layouts/header.html
+++ b/qgis-app/templates/layouts/header.html
@@ -80,40 +80,36 @@
                             {% endif %}
                         {% endif %}
                     {% endfor %}
+                    {% if user.is_authenticated %}
+                        <div class="navbar-item has-dropdown is-hoverable p-0">
+                            <a href="#" class="navbar-link has-text-weight-semibold is-size-7">
+                                <i class="fas fa-user mr-3"></i>
+                                {{ user.get_full_name|default:user.username }}
+                            </a>
+                            <div class="navbar-dropdown">
+                                <a href='{% url "logout" %}' class="navbar-item has-text-weight-semibold is-size-7">
+                                    {% trans "Logout" %}
+                                </a>
+                            </div>
+                        </div>
+                    {% else %}
+                    <a class="navbar-item has-text-weight-semibold is-size-7" href="/accounts/login/">
+                        <span class="mr-2">
+                            <i class="fas fa-sign-in-alt"></i>
+                        </span>
+                        <span>
+                            {% trans "Login" %}
+                        </span>
+                    </a>
+                    {% endif %}
 
                 </div>
                 <div class="navbar-end">
-                    <div>
-                        <div class="control has-icons-right search-control">
-                            <form action="{% url "haystack_search" %}" method="get" style="margin:0;">
-                                <input class="input is-small"  id="id_q" name="q" type="text" placeholder="Search">
-                                <span class="icon is-right"><i class="fa-solid fa-magnifying-glass"></i></span>
-                            </form>
-                        </div>
-                    </div>
-                    <div class="navbar-item p-0 ml-1">
-                        {% if user.is_authenticated %}
-                            <div class="navbar-item has-dropdown is-hoverable p-0">
-                                <a href="#" class="navbar-link has-text-weight-semibold is-size-7">
-                                    <i class="fas fa-user mr-3"></i>
-                                    {{ user.get_full_name|default:user.username }}
-                                </a>
-                                <div class="navbar-dropdown">
-                                    <a href='{% url "logout" %}' class="navbar-item has-text-weight-semibold is-size-7">{% trans "Logout" %}</a>
-                                </div>
-                            </div>
-                        {% else %}
-                        <a class="button is-info is-small" href="{% url "login" %}">
-                            <span class="mr-2">
-                                <i class="fas fa-sign-in-alt"></i>
-                            </span>
-                            <span>
-                                {% trans "Login" %}
-                            </span>
-                        </a>
-                        {% endif %}
-                        {% block navigation_extra %}
-                        {% endblock %}
+                    <div class="control has-icons-right search-control">
+                        <form action="{% url "haystack_search" %}" method="get" style="margin:0;">
+                            <input class="input is-small"  id="id_q" name="q" type="text" placeholder="Search">
+                            <span class="icon is-right"><i class="fa-solid fa-magnifying-glass"></i></span>
+                        </form>
                     </div>
                 </div>
             </div>

--- a/qgis-app/templates/registration/login.html
+++ b/qgis-app/templates/registration/login.html
@@ -10,7 +10,7 @@
         <div class="has-text-centered">
           <h3 class="title">{% trans "Login using your OSGEO id." %}</h3>
           <hr class="login-hr" />
-          <p class="subtitle">
+          <p class="subtitle has-text-danger has-text-weight-bold">
             {% trans "Please note that you do not need a login to download a plugin." %}
           </p>
           <p class="subtitle">


### PR DESCRIPTION
Closes #245 

Separate PR from #225 

Cc @jayenashar 

## Move the login after the Metrics menu (1) and invite the user to use th plugin manager (2 already implemented)

<img width="1352" height="1231" alt="image" src="https://github.com/user-attachments/assets/977e9b73-97db-47fe-83a3-f38bef90cef9" />

## Highlight the note that downloading a plugin doesn't require a login

<img width="507" height="560" alt="image" src="https://github.com/user-attachments/assets/b23dd2f4-e439-4608-8175-cdd22a8f17f9" />
