### PR TITLE
Enhance search functionality

### DIFF
--- a/qgis-app/custom_haystack_urls.py
+++ b/qgis-app/custom_haystack_urls.py
@@ -25,7 +25,13 @@ class SearchWithRequest(SearchView):
             sqs5 = SearchQuerySet().filter(
                 package_name_auto=self.request.GET.get("q", "")
             )
-            form_kwargs["searchqueryset"] = sqs1 | sqs2 | sqs3 | sqs4 | sqs5
+            sqs6 = SearchQuerySet().filter(
+                author_auto=self.request.GET.get("q", "")
+            )
+            sqs7 = SearchQuerySet().filter(
+                created_by_auto=self.request.GET.get("q", "")
+            )
+            form_kwargs["searchqueryset"] = sqs1 | sqs2 | sqs3 | sqs4 | sqs5 | sqs6 | sqs7
 
         return super(SearchWithRequest, self).build_form(form_kwargs)
 

--- a/qgis-app/plugins/search_indexes.py
+++ b/qgis-app/plugins/search_indexes.py
@@ -11,6 +11,16 @@ class PluginIndex(indexes.SearchIndex, indexes.Indexable):
     description_auto = indexes.EdgeNgramField(model_attr="description")
     about_auto = indexes.EdgeNgramField(model_attr="about", default="")
     package_name_auto = indexes.EdgeNgramField(model_attr="package_name", default="")
+    author_auto = indexes.EdgeNgramField(model_attr="author", default="")
+    created_by_auto = indexes.EdgeNgramField()
+
+    def prepare_created_by_auto(self, obj):
+        parts = [
+            obj.created_by.username,
+            obj.created_by.first_name,
+            obj.created_by.last_name,
+        ]
+        return " ".join(filter(None, parts))
 
     def get_model(self):
         return Plugin

--- a/qgis-app/templates/search/indexes/plugins/plugin_text.txt
+++ b/qgis-app/templates/search/indexes/plugins/plugin_text.txt
@@ -2,5 +2,7 @@
 {{ object.description }}
 {{ object.package_name }}
 {{ object.created_by.username }}
+{{ object.created_by.first_name }}
+{{ object.created_by.last_name }}
 {{ object.author }}
 {% for tag in object.tags.all %}{{ tag }} {% endfor %}


### PR DESCRIPTION
Closes #193 

Previously, searching for a plugin by its author's name only worked with complete words. For example, searching for `richar` or `duivenv` would not return plugins by "Richard Duivenvoorde", unless the full name was typed exactly.

This change improves the search feature so that partial name queries now match against:

- The plugin's listed author name
- The uploader's username, first name, and last name

Users can now find plugins by typing just a portion of the author's name, making the search experience significantly more intuitive and useful.

**Note: The search index must be rebuilt after deployment for these changes to take effect.**

<img width="1057" height="1026" alt="image" src="https://github.com/user-attachments/assets/991425c6-61a1-4295-8112-9921536ec76d" />
