### PR TITLE
Hide security badge from public view

### DIFF
--- a/qgis-app/plugins/templates/plugins/plugin_detail.html
+++ b/qgis-app/plugins/templates/plugins/plugin_detail.html
@@ -225,6 +225,7 @@
                 <div id="rating"> (<span id="votes">{% firstof votes '0' %}</span>) {% trans "votes" %}&nbsp;<span id="loading" style="display:none">Loading...</span><span id="vote-message" style="display:none"></span></div>
                 <div>
                         {% with release=object.stable|default:object.experimental %}
+                            {% if user.is_staff or user in object.editors %}
                             {% if release %}
                                 {% with security_scan=release.security_scan %}
                                     {% if security_scan.overall_status == 'passed' %}
@@ -265,6 +266,8 @@
                                     {% endif %}
                                 {% endwith %}
                             {% endif %}
+                            {% endif %}
+
                         {% endwith %}
                     </div>
                 <a class="button mt-3" href="{% if object.stable %}{{ object.stable.get_download_url }}{% else %}{{ object.experimental.get_download_url }}{% endif %}">


### PR DESCRIPTION
This will hide security badge from public view but will still be visible for plugins authors and staff
