### PR TITLE
Refactor URL validation

### DIFF
--- a/qgis-app/plugins/tests/test_validator.py
+++ b/qgis-app/plugins/tests/test_validator.py
@@ -5,7 +5,12 @@ import requests
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.test import TestCase
-from plugins.validator import _check_url_link, validator
+from plugins.validator import (
+    URL_CHECK_FALLBACK_HEADERS,
+    URL_CHECK_TIMEOUT,
+    _check_url_link,
+    validator,
+)
 
 TESTFILE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "testfiles"))
 
@@ -253,26 +258,91 @@ class TestCheckUrlLinkRejectsHeadOnlyFailures(TestCase):
         mock_get.return_value = self._make_response(404)
         with self.assertRaises(ValidationError) as error:
             _check_url_link(self.URLS)
-        self.assertIn("cannot be reached", error.exception.messages[0])
-        self.assertNotIn("seconds", error.exception.messages[0])
+        self.assertIn("could not be reached", error.exception.messages[0])
+        self.assertNotIn("timeout", error.exception.messages[0])
 
     @mock.patch("requests.head", side_effect=requests.exceptions.ConnectionError())
     def test_connection_error_is_not_reported_as_timeout(self, mock_head):
         with self.assertRaises(ValidationError) as error:
             _check_url_link(self.URLS)
-        self.assertNotIn("seconds", error.exception.messages[0])
+        self.assertNotIn("timeout", error.exception.messages[0])
 
     @mock.patch("requests.head", side_effect=requests.exceptions.Timeout())
     def test_timeout_is_reported_as_timeout(self, mock_head):
         with self.assertRaises(ValidationError) as error:
             _check_url_link(self.URLS)
-        self.assertIn("within 10 seconds", error.exception.messages[0])
+        self.assertIn(
+            f"within the {URL_CHECK_TIMEOUT} seconds timeout",
+            error.exception.messages[0],
+        )
 
     @mock.patch("requests.head")
     def test_head_requests_use_a_timeout(self, mock_head):
         mock_head.return_value = self._make_response(200)
         self.assertIsNone(_check_url_link(self.URLS))
-        self.assertEqual(mock_head.call_args.kwargs.get("timeout"), 10)
+        self.assertEqual(mock_head.call_args.kwargs.get("timeout"), URL_CHECK_TIMEOUT)
+
+
+class TestCheckUrlLinkReportsAndRetries(TestCase):
+    """Regression tests for issue #411: hosts such as Codeberg answer 403 to our
+    browser-like user agent, and the error message must name the url that was
+    actually tested plus the reason it failed."""
+
+    URLS = [
+        {
+            "url": "https://codeberg.org/rduivenvoorde/featuregridcreator",
+            "forbidden_url": "forbidden_url",
+            "metadata_attr": "repository",
+        }
+    ]
+
+    def _make_response(self, status_code):
+        response = mock.Mock()
+        response.status_code = status_code
+        return response
+
+    @mock.patch("requests.get")
+    @mock.patch("requests.head")
+    def test_403_is_retried_with_fallback_user_agent(self, mock_head, mock_get):
+        mock_head.return_value = self._make_response(403)
+        mock_get.side_effect = [
+            self._make_response(403),  # GET fallback, still browser-like UA
+            self._make_response(200),  # retry with the honest UA succeeds
+        ]
+        self.assertIsNone(_check_url_link(self.URLS))
+        retry_headers = mock_get.call_args_list[-1].kwargs.get("headers")
+        self.assertEqual(retry_headers, URL_CHECK_FALLBACK_HEADERS)
+
+    @mock.patch("requests.get")
+    @mock.patch("requests.head")
+    def test_error_message_names_url_and_reason(self, mock_head, mock_get):
+        mock_head.return_value = self._make_response(404)
+        mock_get.return_value = self._make_response(404)
+        with self.assertRaises(ValidationError) as error:
+            _check_url_link(self.URLS)
+        message = error.exception.messages[0]
+        self.assertIn(self.URLS[0]["url"], message)
+        self.assertIn("repository", message)
+        self.assertIn("HTTP status 404", message)
+
+    @mock.patch("requests.head")
+    def test_single_stalled_response_is_retried(self, mock_head):
+        # Codeberg intermittently stalls; one slow response must not fail the
+        # upload when the retry succeeds.
+        mock_head.side_effect = [
+            requests.exceptions.Timeout(),
+            self._make_response(200),
+        ]
+        self.assertIsNone(_check_url_link(self.URLS))
+        self.assertEqual(mock_head.call_count, 2)
+
+    @mock.patch("requests.head", side_effect=requests.exceptions.Timeout())
+    def test_timeout_message_names_url(self, mock_head):
+        with self.assertRaises(ValidationError) as error:
+            _check_url_link(self.URLS)
+        message = error.exception.messages[0]
+        self.assertIn(self.URLS[0]["url"], message)
+        self.assertIn(f"{URL_CHECK_TIMEOUT} seconds", message)
 
 
 class TestValidatorForbiddenFileFolder(TestCase):

--- a/qgis-app/plugins/validator.py
+++ b/qgis-app/plugins/validator.py
@@ -16,6 +16,7 @@ import requests
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.forms import ValidationError
+from django.utils.html import escape
 from django.utils.translation import gettext_lazy as _
 
 PLUGIN_MAX_UPLOAD_SIZE = getattr(settings, "PLUGIN_MAX_UPLOAD_SIZE", 25000000)  # 25 mb
@@ -55,16 +56,41 @@ PLUGIN_BOOLEAN_METADATA = getattr(
     ("experimental", "deprecated", "server"),
 )
 
-URL_CHECK_TIMEOUT = 10  # seconds
+URL_CHECK_TIMEOUT = getattr(settings, "URL_CHECK_TIMEOUT", 10)  # seconds per attempt
+
+# A url that stalls once is tried again before the upload is rejected. Keep the
+# product of timeout and attempts below the web server request timeout.
+URL_CHECK_ATTEMPTS = getattr(settings, "URL_CHECK_ATTEMPTS", 2)
 
 # https://stackoverflow.com/a/41950438/10268058
 # add the headers parameter to make the request appears like coming
 # from browser, otherwise some websites will return 403
 URL_CHECK_HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-    "AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/117.0.0.0 Safari/537.36"
+    "User-Agent": getattr(
+        settings,
+        "URL_CHECK_USER_AGENT",
+        "Mozilla/5.0 (X11; Linux x86_64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/140.0.0.0 Safari/537.36",
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
 }
+
+# Some hosts (Codeberg, for instance) actively reject requests that claim to be
+# a browser but are not, answering 403 to the headers above. Retry those with an
+# honest, identifiable user agent before declaring the url unreachable.
+URL_CHECK_FALLBACK_HEADERS = {
+    "User-Agent": getattr(
+        settings,
+        "URL_CHECK_FALLBACK_USER_AGENT",
+        "QGIS-Plugins-Website/1.0 (+https://plugins.qgis.org; link validator)",
+    ),
+    "Accept": "*/*",
+}
+
+# Statuses that usually mean "we do not like your client", not "this url is broken".
+URL_CHECK_RETRY_STATUSES = (401, 403, 406, 409, 429)
 
 
 def _read_from_init(initcontent, initname):
@@ -132,13 +158,13 @@ def _check_url_link(urls):
         except Exception:
             return True
 
-    def request_url(method: str, url: str, **kwargs):
+    def request_url(method: str, url: str, headers=URL_CHECK_HEADERS, **kwargs):
         # Retry without certificate verification when the site presents a
         # certificate we cannot validate, the page itself may still be fine.
         try:
             return method(
                 url,
-                headers=URL_CHECK_HEADERS,
+                headers=headers,
                 timeout=URL_CHECK_TIMEOUT,
                 allow_redirects=True,
                 **kwargs,
@@ -146,17 +172,17 @@ def _check_url_link(urls):
         except requests.exceptions.SSLError:
             return method(
                 url,
-                headers=URL_CHECK_HEADERS,
+                headers=headers,
                 timeout=URL_CHECK_TIMEOUT,
                 allow_redirects=True,
                 verify=False,
                 **kwargs,
             )
 
-    def unreachable_reason(url: str):
+    def check_once(url: str):
         """
-        Returns None when the url can be reached, otherwise "timeout" or
-        "unreachable".
+        Single reachability attempt. Returns (None, None) when the url can be
+        reached, otherwise a ("timeout"|"unreachable", detail) tuple.
         """
         try:
             response = request_url(requests.head, url)
@@ -166,11 +192,37 @@ def _check_url_link(urls):
                 # confirm with a GET before declaring the url broken.
                 response = request_url(requests.get, url, stream=True)
                 response.close()
+            if response.status_code in URL_CHECK_RETRY_STATUSES:
+                # The host is up but refuses our browser-like user agent, ask
+                # again identifying ourselves honestly.
+                response = request_url(
+                    requests.get,
+                    url,
+                    headers=URL_CHECK_FALLBACK_HEADERS,
+                    stream=True,
+                )
+                response.close()
         except requests.exceptions.Timeout:
-            return "timeout"
-        except Exception:
-            return "unreachable"
-        return None if response.status_code < 400 else "unreachable"
+            return "timeout", _("no response within %s seconds") % URL_CHECK_TIMEOUT
+        except Exception as e:
+            return "unreachable", type(e).__name__
+        if response.status_code < 400:
+            return None, None
+        return "unreachable", _("HTTP status %s") % response.status_code
+
+    def unreachable_reason(url: str):
+        """
+        Like check_once, but a stalled response is retried before it fails the
+        upload: hosts such as Codeberg intermittently take a very long time to
+        answer, and a single slow response should not block a plugin release.
+        """
+        for attempt in range(URL_CHECK_ATTEMPTS):
+            reason, detail = check_once(url)
+            if reason != "timeout":
+                return reason, detail
+        return "timeout", _(
+            "no response within %(timeout)s seconds, after %(attempts)s attempts"
+        ) % {"timeout": URL_CHECK_TIMEOUT, "attempts": URL_CHECK_ATTEMPTS}
 
     url_error = [
         url_item["metadata_attr"]
@@ -185,30 +237,47 @@ def _check_url_link(urls):
             )
         )
 
-    reasons = {
-        url_item["metadata_attr"]: unreachable_reason(url_item["url"])
+    # Report the url that was actually tested and why it failed, otherwise the
+    # uploader cannot tell which link (or which value of it) is the problem.
+    def format_failures(failures):
+        # The url comes straight from the uploaded metadata.txt and the message
+        # is rendered as html, so escape it.
+        return "<br />".join(
+            f"<strong>{attr}</strong>: <code>{escape(url)}</code> ({detail})"
+            for attr, url, detail in failures
+        )
+
+    reasons = [
+        (url_item["metadata_attr"], url_item["url"])
+        + unreachable_reason(url_item["url"])
         for url_item in urls
-    }
+    ]
     timeout_url_error = [
-        attr for attr, reason in reasons.items() if reason == "timeout"
+        (attr, url, detail)
+        for attr, url, reason, detail in reasons
+        if reason == "timeout"
     ]
     if len(timeout_url_error) > 0:
-        timeout_url_error_str = ", ".join(timeout_url_error)
         raise ValidationError(
             _(
-                f"Please provide valid url link for the following key(s) in the metadata source: <strong>{timeout_url_error_str}</strong>. "
-                f"The website(s) cannot be reached within {URL_CHECK_TIMEOUT} seconds."
+                "The following url(s) in the metadata source could not be reached "
+                f"within the {URL_CHECK_TIMEOUT} seconds timeout:<br />"
+                f"{format_failures(timeout_url_error)}<br />"
+                "Please check the link(s), or try again later if the server is "
+                "temporarily slow."
             )
         )
     exist_url_error = [
-        attr for attr, reason in reasons.items() if reason == "unreachable"
+        (attr, url, detail)
+        for attr, url, reason, detail in reasons
+        if reason == "unreachable"
     ]
     if len(exist_url_error) > 0:
-        exist_url_error_str = ", ".join(exist_url_error)
         raise ValidationError(
             _(
-                f"Please provide valid url link for the following key(s) in the metadata source: <strong>{exist_url_error_str}</strong>. "
-                "The website(s) cannot be reached."
+                "The following url(s) in the metadata source could not be reached:"
+                f"<br />{format_failures(exist_url_error)}<br />"
+                "Please provide valid url link(s) in the metadata source."
             )
         )
 


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Closes #411

### What was wrong

A developer couldn't upload their plugin: the site claimed their repository, tracker and homepage were "not reachable", though all three opened fine in a browser.

We were being blocked, not timing out. When checking a plugin's metadata URLs, the site identified itself as a web browser — but that identity was hard-coded years ago and had gone stale, claiming a Chrome version several years old. Codeberg treats an outdated browser identity as a bot and refuses the request. We recorded "could not reach", and the upload failed. Verified against the reported URL: with the old identity Codeberg refuses us; with a current or honestly-declared identity it answers in about a second. The developer's links were always fine.

It was hard to diagnose because the error named only the failing metadata fields — not which URL was tested, nor why. The developer couldn't tell if we were checking their metadata.txt or stale profile URLs, or whether the cause was a bad link, a slow server, or a refusal.

Codeberg's occasional slowness was a real but secondary factor: one stalled response failed the whole upload, with no retry.

### What changed

1. Anti-bot rules no longer block the check. The browser identity is current, and if a server still refuses, we ask again identifying honestly as the QGIS plugins link checker — covering hosts that reject non-browsers and those that reject fake-looking browsers.
2. Errors say what failed and why — the metadata field, the exact URL tested, and the concrete reason (refusal, missinno response in time).
3. A single slow response no lon are retried once; genuine
   failures still fail immediately.
4. Timing is configurable insteaempt limit stays at the original
   10 seconds.

## Author's checklist

- [x] I have read the [contributing guidelines](https://github.com/qgis/QGIS-Plugins-Website/blob/master/CONTRIBUTING.md) and my pull request follows them.
- [x] my commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools _must_ be indicated. Failure to be honest might result in banning.

<!--
**BEFORE HITTING SUBMIT** -- Please SPIN UP THE DOCKERIZED PROJECT AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the project maintainers to do this for you!

IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
===========================================

Congratulations, you are about to make a pull request to QGIS or one of its related project! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
Include both: *what* you changed and *why* you changed it.

If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.


----

Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
Feel free to ask in a comment if you have troubles with any of them.

- Commit messages are descriptive and explain the rationale for changes.

- Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

- New unit tests have been added for relevant changes

- you have read and acknowledged [the contributing guidelines](https://github.com/qgis/QGIS-Plugins-Website?tab=contributing-ov-file) and your PR complies with
-->

## Reviewer's checklist

- [ ] I remember to check the "Author's checklist" above and ask the author to update the PR description if any of the items are not checked.
- [ ] I remember that welcoming new contributors is more important than nitpicking on code style. I will be kind and respectful in my review comments.
